### PR TITLE
fix: add --yes option to publish command

### DIFF
--- a/commands/globals.py
+++ b/commands/globals.py
@@ -20,9 +20,6 @@ visual_studio_path = ""
 developer_env = dict()
 vcpkg_dependencies = set()
 
-# CLI flags
-always_yes = False
-
 
 def init_globals(**kwargs):
     """
@@ -36,10 +33,9 @@ def init_globals(**kwargs):
         ninja_path: Path to ninja (Windows)
         visual_studio_path: Path to Visual Studio (Windows)
         developer_env: Developer environment variables (Windows)
-        always_yes: always yes to all prompts
     """
     global os_type, architecture, os_version, script_directory
-    global ninja_path, visual_studio_path, developer_env, always_yes
+    global ninja_path, visual_studio_path, developer_env
 
     os_type = kwargs.get("os_type", "")
     architecture = kwargs.get("architecture", "")
@@ -48,4 +44,3 @@ def init_globals(**kwargs):
     ninja_path = kwargs.get("ninja_path", "")
     visual_studio_path = kwargs.get("visual_studio_path", "")
     developer_env = kwargs.get("developer_env", {})
-    always_yes = kwargs.get("always_yes", False)

--- a/commands/publish.py
+++ b/commands/publish.py
@@ -25,7 +25,7 @@ from commands.setup import (
 )
 
 
-def publish(target, build_type):
+def publish(target, build_type, skip_confirm=False):
     """
     Builds the project, creates a release archive, and uploads it to GitHub,
     prompting for overwrite if the asset already exists.
@@ -261,8 +261,8 @@ def publish(target, build_type):
                     f"✅ Successfully created new release and uploaded '{archive_filename}'."
                 )
             elif asset_exists:
-                should_overwrite = g.always_yes or release_is_prerelease
-                if release_is_prerelease and not g.always_yes:
+                should_overwrite = skip_confirm or release_is_prerelease
+                if release_is_prerelease and not skip_confirm:
                     print(
                         "ℹ️ Release is marked as prerelease; overwriting existing asset without confirmation."
                     )
@@ -369,9 +369,10 @@ def publish_command(target, build_type, yes):
     \b
     Note: Previously called 'release' command.
     """
+    skip_confirm = False
     if yes:
         click.echo("⚠️  Auto-confirm enabled: All prompts will be accepted.")
-        g.always_yes = True
+        skip_confirm = True
 
     click.echo(f"📦 Publishing {target} ({build_type} build)...")
-    publish(target, build_type)
+    publish(target, build_type, skip_confirm)

--- a/commands/setup.py
+++ b/commands/setup.py
@@ -71,9 +71,7 @@ def process_build_targets(targets):
 
     # Check if targets specify a directory path
     if len(targets) > 1 and (Path(script_directory) / "src" / targets[0]).exists():
-        repo_name = get_repo_name_from_path(
-            Path(script_directory) / "src" / targets[0]
-        )
+        repo_name = get_repo_name_from_path(Path(script_directory) / "src" / targets[0])
         if repo_name and repo_name in repos_to_ignore:
             click.echo(
                 f"⚠️  Repository '{repo_name}' is configured to be ignored. Skipping."
@@ -1205,6 +1203,7 @@ def _print_ignore_lists(packages_to_ignore, repos_to_ignore):
     """
     Display the currently configured package/repo ignore lists.
     """
+
     def format_list(items):
         return ", ".join(sorted(items)) if items else "none"
 


### PR DESCRIPTION
## Summary
Enables the --yes option to work with the publish command.
_(I missed to porting this code while refactoring)_

## Changes
- **commands/publish.py**: Add --yes/-y option to publish_command so it can be parsed when specified 
after the command name (e.g., `raisin publish pkg --yes`)