### PR TITLE
fix: correct RSA algorithm name and handle null tokens

### DIFF
--- a/commands/install.py
+++ b/commands/install.py
@@ -230,7 +230,7 @@ def install_command(
             continue
 
         owner, repo_name = match.groups()
-        token = tokens.get(owner, tokens.get("default"))
+        token = tokens.get(owner, tokens.get("default")) if tokens else None
         if token:
             session.headers.update(
                 {

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -252,7 +252,7 @@ def _sign_nonce(nonce: str, key_path: Path) -> str:
         raw_sig = private_key.sign(data)
 
     elif isinstance(private_key, rsa.RSAPrivateKey):
-        algo = b"ssh-rsa"
+        algo = b"rsa-sha2-256"
         raw_sig = private_key.sign(data, padding.PKCS1v15(), hashes.SHA256())
 
     elif isinstance(private_key, ec.EllipticCurvePrivateKey):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ certifi==2025.10.5
 cfgv==3.4.0
 charset-normalizer==3.4.4
 click==8.3.0
+cryptography==41.0.7
 detect-secrets==1.5.0
 distlib==0.4.0
 filelock==3.20.0


### PR DESCRIPTION
- Change RSA signature algorithm from 'ssh-rsa' to 'rsa-sha2-256' to match SHA256 hash actually used in signing (fixes SSH verification failure)
- Add null check for tokens dict in install.py to prevent AttributeError when no GitHub tokens are configured