### PR TITLE
fix: clean stale cmake build dir before each publish

### DIFF
--- a/commands/publish.py
+++ b/commands/publish.py
@@ -167,6 +167,11 @@ def _build_package(
     install_dir = paths["install_dir"]
     target_dir = paths["target_dir"]
 
+    # Clean stale build directory to prevent cached cmake paths from
+    # interfering (e.g., system zstd vs install/ zstd).
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+
     print(f"\n--- Setting up build for '{target}' ---")
     setup(
         package_name=target,


### PR DESCRIPTION
Prevents cached cmake paths (e.g., system zstd) from interfering with publish builds. Without this, a failed publish attempt could cache incorrect package paths that persist on retries.