### PR TITLE
feat: record OTA install metadata

### DIFF
--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -51,6 +51,9 @@ DEFAULT_OTA_ENDPOINT = "https://raisin-ota-api.raionrobotics.com/api"
 # Persistent token cache file name (stored in script_directory)
 _TOKEN_CACHE_FILE = ".ota_token_cache.json"
 
+# Per-install metadata file written after OTA extraction
+_INSTALL_METADATA_FILE = "ota-install.json"
+
 
 # ============================================================================
 # Configuration
@@ -665,11 +668,31 @@ def _download_package_blob(
     return _stream_download(url, download_path, package_name)
 
 
+def _write_install_metadata(install_dir: Path, metadata: Optional[dict]) -> None:
+    """Persist OTA install metadata next to the extracted package.
+
+    This is written after extraction, so it does not affect the archive blob hash.
+    """
+    if not metadata:
+        return
+
+    metadata_path = install_dir / _INSTALL_METADATA_FILE
+    try:
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"📝 Recorded OTA metadata: {metadata_path}")
+    except OSError as e:
+        print(f"⚠️ Failed to write OTA metadata for '{install_dir.name}': {e}")
+
+
 def _extract_and_read_deps(
     download_file: Path,
     install_dir: Path,
     package_name: str,
     version: str,
+    install_metadata: Optional[dict] = None,
 ) -> Optional[dict]:
     """Extract downloaded package and read dependencies.
 
@@ -690,6 +713,7 @@ def _extract_and_read_deps(
         return None
 
     print(f"✅ Successfully installed '{package_name}=={version}' from OTA server.")
+    _write_install_metadata(install_dir, install_metadata)
 
     # Read dependencies from release.yaml
     dependencies = []
@@ -792,7 +816,32 @@ def download_package(
     if not _download_package_blob(archive_id, pkg_id, package_name, download_file):
         return None
 
-    return _extract_and_read_deps(download_file, install_dir, package_name, version)
+    install_metadata = {
+        "schemaVersion": 1,
+        "source": "archive",
+        "installedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "otaEndpoint": get_ota_endpoint(),
+        "platform": platform_str,
+        "buildType": build_type,
+        "archiveName": archive_name,
+        "archiveId": archive_id,
+        "archiveVersion": actual_version,
+        "requestedArchiveVersion": archive_version,
+        "packageName": package_name,
+        "packageId": pkg_id,
+        "packageVersion": version,
+        "packageTag": tag or f"v{version}",
+        "manifestHash": best_pkg.get("manifestHash"),
+        "blobHash": best_pkg.get("blobHash"),
+    }
+
+    return _extract_and_read_deps(
+        download_file,
+        install_dir,
+        package_name,
+        version,
+        install_metadata=install_metadata,
+    )
 
 
 def download_all_from_archive(
@@ -864,7 +913,32 @@ def download_all_from_archive(
         if not _download_package_blob(archive_id, pkg_id, name, download_file):
             continue
 
-        result = _extract_and_read_deps(download_file, install_dir, name, version)
+        install_metadata = {
+            "schemaVersion": 1,
+            "source": "archive",
+            "installedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "otaEndpoint": get_ota_endpoint(),
+            "platform": platform_str,
+            "buildType": build_type,
+            "archiveName": archive_name,
+            "archiveId": archive_id,
+            "archiveVersion": actual_version,
+            "requestedArchiveVersion": archive_version,
+            "packageName": name,
+            "packageId": pkg_id,
+            "packageVersion": version,
+            "packageTag": tag or f"v{version}",
+            "manifestHash": pkg.get("manifestHash"),
+            "blobHash": pkg.get("blobHash"),
+        }
+
+        result = _extract_and_read_deps(
+            download_file,
+            install_dir,
+            name,
+            version,
+            install_metadata=install_metadata,
+        )
         if result:
             results[name] = result
 
@@ -959,7 +1033,8 @@ def download_package_at_timestamp(
             return None
 
         blob_hash = manifest.get("blobHash")
-        version = manifest.get("version", "0.0.0")
+        raw_version = manifest.get("version", "0.0.0")
+        version = raw_version.lstrip("v") if raw_version else "0.0.0"
 
         if not blob_hash:
             print(f"⚠️ Manifest for '{package_name}' has no blob hash")
@@ -982,7 +1057,31 @@ def download_package_at_timestamp(
         if not _download_blob_by_hash(blob_hash, download_file):
             return None
 
-        return _extract_and_read_deps(download_file, install_dir, package_name, version)
+        install_metadata = {
+            "schemaVersion": 1,
+            "source": "timestamp",
+            "installedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "otaEndpoint": get_ota_endpoint(),
+            "platform": platform_str,
+            "buildType": build_type,
+            "requestedTimestamp": timestamp,
+            "packageName": package_name,
+            "packageId": package_id,
+            "packageVersion": version,
+            "packageTag": f"v{version.lstrip('v')}",
+            "manifestHash": manifest.get("manifestHash"),
+            "blobHash": blob_hash,
+            "manifestId": manifest.get("id"),
+            "manifestCreatedAt": manifest.get("createdAt"),
+        }
+
+        return _extract_and_read_deps(
+            download_file,
+            install_dir,
+            package_name,
+            version,
+            install_metadata=install_metadata,
+        )
 
     except requests.HTTPError as e:
         if e.response is not None and e.response.status_code == 404:

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -726,6 +726,41 @@ def _extract_and_read_deps(
     return {"version": version, "dependencies": dependencies}
 
 
+def _build_archive_install_metadata(
+    package_name: str,
+    package_id: str,
+    package_tag: str,
+    version: str,
+    build_type: str,
+    platform_str: str,
+    archive_name: str,
+    archive_id: str,
+    actual_version: Optional[str],
+    requested_archive_version: Optional[str],
+    manifest_hash: Optional[str],
+    blob_hash: Optional[str],
+) -> dict:
+    """Build install metadata for archive-based OTA downloads."""
+    return {
+        "schemaVersion": 1,
+        "source": "archive",
+        "installedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "otaEndpoint": get_ota_endpoint(),
+        "platform": platform_str,
+        "buildType": build_type,
+        "archiveName": archive_name,
+        "archiveId": archive_id,
+        "archiveVersion": actual_version,
+        "requestedArchiveVersion": requested_archive_version,
+        "packageName": package_name,
+        "packageId": package_id,
+        "packageVersion": version,
+        "packageTag": package_tag or f"v{version}",
+        "manifestHash": manifest_hash,
+        "blobHash": blob_hash,
+    }
+
+
 def download_package(
     package_name: str,
     spec_str: str,
@@ -816,24 +851,20 @@ def download_package(
     if not _download_package_blob(archive_id, pkg_id, package_name, download_file):
         return None
 
-    install_metadata = {
-        "schemaVersion": 1,
-        "source": "archive",
-        "installedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "otaEndpoint": get_ota_endpoint(),
-        "platform": platform_str,
-        "buildType": build_type,
-        "archiveName": archive_name,
-        "archiveId": archive_id,
-        "archiveVersion": actual_version,
-        "requestedArchiveVersion": archive_version,
-        "packageName": package_name,
-        "packageId": pkg_id,
-        "packageVersion": version,
-        "packageTag": tag or f"v{version}",
-        "manifestHash": best_pkg.get("manifestHash"),
-        "blobHash": best_pkg.get("blobHash"),
-    }
+    install_metadata = _build_archive_install_metadata(
+        package_name=package_name,
+        package_id=pkg_id,
+        package_tag=tag,
+        version=version,
+        build_type=build_type,
+        platform_str=platform_str,
+        archive_name=archive_name,
+        archive_id=archive_id,
+        actual_version=actual_version,
+        requested_archive_version=archive_version,
+        manifest_hash=best_pkg.get("manifestHash"),
+        blob_hash=best_pkg.get("blobHash"),
+    )
 
     return _extract_and_read_deps(
         download_file,
@@ -913,24 +944,20 @@ def download_all_from_archive(
         if not _download_package_blob(archive_id, pkg_id, name, download_file):
             continue
 
-        install_metadata = {
-            "schemaVersion": 1,
-            "source": "archive",
-            "installedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            "otaEndpoint": get_ota_endpoint(),
-            "platform": platform_str,
-            "buildType": build_type,
-            "archiveName": archive_name,
-            "archiveId": archive_id,
-            "archiveVersion": actual_version,
-            "requestedArchiveVersion": archive_version,
-            "packageName": name,
-            "packageId": pkg_id,
-            "packageVersion": version,
-            "packageTag": tag or f"v{version}",
-            "manifestHash": pkg.get("manifestHash"),
-            "blobHash": pkg.get("blobHash"),
-        }
+        install_metadata = _build_archive_install_metadata(
+            package_name=name,
+            package_id=pkg_id,
+            package_tag=tag,
+            version=version,
+            build_type=build_type,
+            platform_str=platform_str,
+            archive_name=archive_name,
+            archive_id=archive_id,
+            actual_version=actual_version,
+            requested_archive_version=archive_version,
+            manifest_hash=pkg.get("manifestHash"),
+            blob_hash=pkg.get("blobHash"),
+        )
 
         result = _extract_and_read_deps(
             download_file,

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -684,7 +684,9 @@ def _write_install_metadata(install_dir: Path, metadata: Optional[dict]) -> None
         )
         print(f"📝 Recorded OTA metadata: {metadata_path}")
     except OSError as e:
-        print(f"⚠️ Failed to write OTA metadata for '{install_dir.name}': {e}")
+        print(
+            f"⚠️ Failed to write OTA metadata for '{install_dir.absolute().as_posix()}': {e}"
+        )
 
 
 def _extract_and_read_deps(

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -1068,7 +1068,7 @@ def download_package_at_timestamp(
             "packageName": package_name,
             "packageId": package_id,
             "packageVersion": version,
-            "packageTag": f"v{version.lstrip('v')}",
+            "packageTag": f"v{version}",
             "manifestHash": manifest.get("manifestHash"),
             "blobHash": blob_hash,
             "manifestId": manifest.get("id"),

--- a/test_ota.py
+++ b/test_ota.py
@@ -726,9 +726,30 @@ class TestDownload(unittest.TestCase):
 
             result = ota.download_package("mypkg", "", "release", install_base)
 
+            metadata_path = (
+                install_base
+                / "mypkg"
+                / "linux"
+                / "22.04"
+                / "x86_64"
+                / "release"
+                / ota._INSTALL_METADATA_FILE
+            )
+            self.assertTrue(metadata_path.is_file())
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
         self.assertIsNotNone(result)
         self.assertEqual(result["version"], "1.2.0")
         self.assertIn("depA", result["dependencies"])
+        self.assertEqual(metadata["source"], "archive")
+        self.assertEqual(metadata["archiveId"], "arch-1")
+        self.assertEqual(metadata["archiveVersion"], "v2024.01")
+        self.assertEqual(metadata["packageId"], "p1")
+        self.assertEqual(metadata["packageVersion"], "1.2.0")
+        self.assertEqual(metadata["packageTag"], "v1.2.0")
+        self.assertEqual(metadata["manifestHash"], "a" * 64)
+        self.assertEqual(metadata["requestedArchiveVersion"], None)
+        self.assertIn("installedAt", metadata)
 
     @patch("commands.ota_client._download_package_blob", return_value=True)
     @patch("commands.ota_client._fetch_archive_manifest")
@@ -903,17 +924,46 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
                 "mypkg", "2024-01-15T10:00:00Z", "release", install_base
             )
 
+            metadata_path = (
+                install_base
+                / "mypkg"
+                / "linux"
+                / "22.04"
+                / "x86_64"
+                / "release"
+                / ota._INSTALL_METADATA_FILE
+            )
+            self.assertTrue(metadata_path.is_file())
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
         self.assertIsNotNone(result)
         self.assertEqual(result["version"], "1.5.0")
         self.assertIn("depB", result["dependencies"])
+        self.assertEqual(metadata["source"], "timestamp")
+        self.assertEqual(metadata["otaEndpoint"], "https://ota.example.com")
+        self.assertEqual(metadata["requestedTimestamp"], "2024-01-15T10:00:00Z")
+        self.assertEqual(metadata["packageId"], "pkg-uuid")
+        self.assertEqual(metadata["packageVersion"], "1.5.0")
+        self.assertEqual(metadata["blobHash"], "abc123" * 10 + "abcd")
+        self.assertIn("installedAt", metadata)
 
     @patch("commands.ota_client._download_package_blob", return_value=True)
     @patch("commands.ota_client._fetch_archive_manifest")
     def test_download_all_from_archive(self, mock_manifest, mock_blob):
         """Download all packages from an archive."""
         packages = [
-            {"packageName": "pkg1", "tagName": "v1.0.0", "packageId": "p1"},
-            {"packageName": "pkg2", "tagName": "v2.0.0", "packageId": "p2"},
+            {
+                "packageName": "pkg1",
+                "tagName": "v1.0.0",
+                "packageId": "p1",
+                "manifestHash": "a" * 64,
+            },
+            {
+                "packageName": "pkg2",
+                "tagName": "v2.0.0",
+                "packageId": "p2",
+                "manifestHash": "b" * 64,
+            },
         ]
         mock_manifest.return_value = (packages, "arch-1", "v2024.01")
 
@@ -931,11 +981,27 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
 
             result = ota.download_all_from_archive("release", install_base)
 
+            metadata_path = (
+                install_base
+                / "pkg1"
+                / "linux"
+                / "22.04"
+                / "x86_64"
+                / "release"
+                / ota._INSTALL_METADATA_FILE
+            )
+            self.assertTrue(metadata_path.is_file())
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
         self.assertEqual(len(result), 2)
         self.assertIn("pkg1", result)
         self.assertIn("pkg2", result)
         self.assertEqual(result["pkg1"]["version"], "1.0.0")
         self.assertEqual(result["pkg2"]["version"], "2.0.0")
+        self.assertEqual(metadata["source"], "archive")
+        self.assertEqual(metadata["archiveVersion"], "v2024.01")
+        self.assertEqual(metadata["packageId"], "p1")
+        self.assertEqual(metadata["manifestHash"], "a" * 64)
 
     @patch(
         "commands.ota_client._fetch_archive_manifest",


### PR DESCRIPTION
## Summary

OTA installs recorded package versions and commit snapshots, but they did not persist the OTA archive/manfiest identity that selected the downloaded blob. That made it impossible to answer basic questions from an existing install such as which archive version was installed, when it was installed, and which manifest or blob hash the OTA page would show for that package.

This also created confusion around `release.txt`. The file is bundled in published artifacts and can contribute to zip churn, but it does not provide enough information to reconstruct the OTA lineage of a historical install. Users could recover the source commits that were present at publish time, but not the archive version, archive id, manifest hash, or install timestamp that identify the exact OTA object.

## Root Cause

The OTA client fetched archive and manifest information during install, then discarded it after extracting the zip. The server-facing identifiers were available in memory in `commands/ota_client.py`, but nothing wrote them into the installed package directory. As a result, old installs only kept `release.yaml` and `release.txt`.

## Fix

This change writes a new `ota-install.json` file into each extracted OTA install directory after extraction completes. Because the file is written at install time rather than publish time, it does not alter the published zip contents or the OTA blob hash.

For archive-based installs, the metadata now records archive name, archive id, archive version, requested archive version, package id, package version/tag, manifest hash, blob hash, platform, build type, OTA endpoint, and install timestamp.

For timestamp-based installs, the metadata records the requested timestamp plus the manifest id/created-at values when the server returns them, along with the same package/blob identity fields.

## Validation

- Ran `pytest test_ota.py -q`

- Verified new coverage for archive downloads, `download_all_from_archive`, and timestamp-based installs

## Notes

This improves forward traceability only. Existing installs do not contain archive metadata retroactively; they would need to be reinstalled to gain `ota-install.json`.
