### PR TITLE
[Fix] prune non-target publish interfaces

### DIFF
--- a/commands/publish.py
+++ b/commands/publish.py
@@ -91,6 +91,59 @@ def _validate_target(target_dir: Path) -> Optional[dict]:
         return None
 
 
+def _parse_dependency_name(dependency_spec: str) -> Optional[str]:
+    """Extract the package name from a release.yaml dependency spec."""
+    match = re.match(r"^\s*([a-zA-Z0-9_.-]+)", str(dependency_spec))
+    return match.group(1) if match else None
+
+
+def _get_release_install_prefix(package_name: str, build_type: str) -> Path:
+    """Return the expected release/install prefix for one package."""
+    return (
+        Path(g.script_directory)
+        / "release"
+        / "install"
+        / package_name
+        / g.os_type
+        / g.os_version
+        / g.architecture
+        / build_type
+    )
+
+
+def _get_missing_publish_dependencies(
+    details: dict, build_type: str
+) -> list[tuple[str, Path]]:
+    """Return declared dependencies that are not installed as release artifacts."""
+    missing = []
+    for dependency_spec in details.get("dependencies") or []:
+        package_name = _parse_dependency_name(dependency_spec)
+        if not package_name:
+            continue
+
+        prefix = _get_release_install_prefix(package_name, build_type)
+        if not prefix.is_dir() or not (prefix / "release.yaml").is_file():
+            missing.append((str(dependency_spec), prefix))
+
+    return missing
+
+
+def _validate_publish_dependencies(details: dict, build_type: str) -> bool:
+    """Ensure publish builds use installed release artifacts for dependencies."""
+    missing = _get_missing_publish_dependencies(details, build_type)
+    if not missing:
+        return True
+
+    print("❌ Error: Publish dependencies are not installed as release artifacts.")
+    print(
+        "   Run `raisin install` for the dependencies in release.yaml before "
+        "publishing, so the build does not depend on mutable src checkouts."
+    )
+    for dependency_spec, prefix in missing:
+        print(f"   - {dependency_spec}: missing {prefix / 'release.yaml'}")
+    return False
+
+
 # ============================================================================
 # Build
 # ============================================================================
@@ -101,11 +154,41 @@ def _get_publish_march() -> str:
     return os.environ.get("RAISIN_MARCH", get_default_portable_march())
 
 
+def _get_release_install_prefixes(target: str, build_type: str) -> list[Path]:
+    """Return installed release package prefixes available to a publish build."""
+    release_install_root = Path(g.script_directory) / "release" / "install"
+    if not release_install_root.is_dir():
+        return []
+
+    prefixes = []
+    for child in sorted(release_install_root.iterdir()):
+        if child.name == target:
+            continue
+
+        prefix = _get_release_install_prefix(child.name, build_type)
+        if prefix.is_dir():
+            prefixes.append(prefix)
+
+    return prefixes
+
+
+def _get_publish_cmake_prefix_path(
+    target: str,
+    build_type: str,
+    install_dir: Path,
+) -> str:
+    """Build the CMAKE_PREFIX_PATH used while publishing one package."""
+    prefixes = [Path(g.script_directory) / "install", install_dir]
+    prefixes.extend(_get_release_install_prefixes(target, build_type))
+    return ";".join(str(prefix) for prefix in prefixes)
+
+
 def _build_linux(
     build_dir: Path,
     install_dir: Path,
     build_type: str,
     raisin_march: str,
+    cmake_prefix_path: str,
 ):
     """Run CMake + Ninja build on Linux."""
     cmake_cmd = [
@@ -117,6 +200,7 @@ def _build_linux(
         "-B",
         str(build_dir),
         f"-DCMAKE_INSTALL_PREFIX={install_dir}",
+        f"-DCMAKE_PREFIX_PATH={cmake_prefix_path}",
         f"-DCMAKE_BUILD_TYPE={build_type}",
         "-DRAISIN_RELEASE_BUILD=ON",
         f"-DRAISIN_MARCH={raisin_march}",
@@ -159,7 +243,12 @@ def _build_linux(
                 raise
 
 
-def _build_windows(build_dir: Path, install_dir: Path, build_type: str):
+def _build_windows(
+    build_dir: Path,
+    install_dir: Path,
+    build_type: str,
+    cmake_prefix_path: str,
+):
     """Run CMake + build on Windows."""
     cmake_cmd = [
         "cmake",
@@ -171,6 +260,7 @@ def _build_windows(build_dir: Path, install_dir: Path, build_type: str):
         str(build_dir),
         f"-DCMAKE_TOOLCHAIN_FILE={g.script_directory}/vcpkg/scripts/buildsystems/vcpkg.cmake",
         f"-DCMAKE_INSTALL_PREFIX={install_dir}",
+        f"-DCMAKE_PREFIX_PATH={cmake_prefix_path}",
         "-DRAISIN_RELEASE_BUILD=ON",
     ]
     if g.ninja_path:
@@ -194,6 +284,95 @@ def _build_windows(build_dir: Path, install_dir: Path, build_type: str):
     )
 
 
+def _discover_target_package_names(target_dir: Path) -> set[str]:
+    """Return CMake/interface package names owned by a source repo."""
+    package_names: set[str] = set()
+
+    for root, dirs, files in os.walk(target_dir):
+        root_path = Path(root)
+        dirs[:] = [
+            d
+            for d in dirs
+            if d
+            not in {
+                ".git",
+                "build",
+                "cmake-build-debug",
+                "cmake-build-release",
+                "generated",
+                "install",
+                "release",
+                "temp",
+                "__pycache__",
+            }
+        ]
+
+        if "CMakeLists.txt" in files:
+            package_names.add(root_path.name)
+            is_release_repo_root = root_path == target_dir or (
+                root_path.parent == target_dir
+                and (root_path / "release.yaml").is_file()
+            )
+            if not is_release_repo_root:
+                dirs.clear()
+            continue
+
+        if root_path.name in {"msg", "srv", "action"}:
+            expected_suffix = f".{root_path.name}"
+            if any(name.endswith(expected_suffix) for name in files):
+                package_names.add(root_path.parent.name)
+            dirs.clear()
+
+    return package_names
+
+
+def _prune_non_target_publish_artifacts(target_dir: Path, install_dir: Path) -> None:
+    """Remove installed artifacts that are known to belong to other source repos."""
+    package_names = _discover_target_package_names(target_dir)
+    if not package_names:
+        return
+
+    source_package_names = _discover_target_package_names(target_dir.parent)
+    non_target_source_package_names = source_package_names - package_names
+
+    pruned = []
+    generated_packages_to_prune = set()
+    for rel_root in ("messages", "generated/include"):
+        root = install_dir / rel_root
+        if not root.is_dir():
+            continue
+
+        for child in root.iterdir():
+            if not child.is_dir() or child.name in package_names:
+                continue
+
+            generated_packages_to_prune.add(child.name)
+            shutil.rmtree(child)
+            pruned.append(child.relative_to(install_dir).as_posix())
+
+    include_root = install_dir / "include"
+    if include_root.is_dir():
+        include_packages_to_prune = (
+            generated_packages_to_prune | non_target_source_package_names
+        )
+        for child in include_root.iterdir():
+            if (
+                not child.is_dir()
+                or child.name in package_names
+                or child.name not in include_packages_to_prune
+            ):
+                continue
+
+            shutil.rmtree(child)
+            pruned.append(child.relative_to(install_dir).as_posix())
+
+    if pruned:
+        print(
+            f"🧹 Pruned {len(pruned)} non-target publish artifact directories from "
+            f"'{install_dir}'."
+        )
+
+
 def _build_package(
     target: str,
     build_type: str,
@@ -207,6 +386,11 @@ def _build_package(
     install_dir = paths["install_dir"]
     target_dir = paths["target_dir"]
     raisin_march = _get_publish_march()
+    cmake_prefix_path = _get_publish_cmake_prefix_path(
+        target,
+        build_type,
+        install_dir,
+    )
 
     print(f"\n--- Setting up build for '{target}' ---")
     setup(
@@ -219,11 +403,18 @@ def _build_package(
 
     print("⚙️  Running CMake...")
     if platform.system().lower() == "linux":
-        _build_linux(build_dir, install_dir, build_type, raisin_march)
+        _build_linux(
+            build_dir,
+            install_dir,
+            build_type,
+            raisin_march,
+            cmake_prefix_path,
+        )
     else:
-        _build_windows(build_dir, install_dir, build_type)
+        _build_windows(build_dir, install_dir, build_type, cmake_prefix_path)
 
     print(f"✅ Build for '{target}' complete!")
+    _prune_non_target_publish_artifacts(target_dir, install_dir)
 
     # Copy release.yaml and install_dependencies.sh to install dir
     install_dir.mkdir(parents=True, exist_ok=True)
@@ -534,6 +725,8 @@ def publish(
 
     print(f"✅ Found release file for '{target}'.")
     version = details.get("version", "0.0.0")
+    if not _validate_publish_dependencies(details, build_type):
+        return
 
     # Check user type
     _, _, user_type, _, _ = load_configuration()

--- a/test_publish_artifact_pruning.py
+++ b/test_publish_artifact_pruning.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Tests for publish artifact pruning.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from commands import globals as g
+from commands.publish import (
+    _discover_target_package_names,
+    _get_missing_publish_dependencies,
+    _get_publish_cmake_prefix_path,
+    _prune_non_target_publish_artifacts,
+)
+
+
+class TestPublishArtifactPruning(unittest.TestCase):
+    def test_discovers_target_cmake_and_interface_package_names(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_dir = Path(tmpdir) / "src" / "target_repo"
+            (target_dir / "library_pkg").mkdir(parents=True)
+            (target_dir / "library_pkg" / "CMakeLists.txt").write_text(
+                "project(library_pkg)\n",
+                encoding="utf-8",
+            )
+            (target_dir / "interface_pkg" / "msg").mkdir(parents=True)
+            (target_dir / "interface_pkg" / "msg" / "Thing.msg").write_text(
+                "string data\n",
+                encoding="utf-8",
+            )
+
+            package_names = _discover_target_package_names(target_dir)
+
+        self.assertIn("library_pkg", package_names)
+        self.assertIn("interface_pkg", package_names)
+        self.assertNotIn("target_repo", package_names)
+
+    def test_discovers_interfaces_below_repo_root_cmake(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_dir = Path(tmpdir) / "src" / "target_repo"
+            target_dir.mkdir(parents=True)
+            (target_dir / "CMakeLists.txt").write_text(
+                "project(target_repo)\n",
+                encoding="utf-8",
+            )
+            (target_dir / "std_msgs" / "msg").mkdir(parents=True)
+            (target_dir / "std_msgs" / "msg" / "Header.msg").write_text(
+                "string frame_id\n",
+                encoding="utf-8",
+            )
+
+            package_names = _discover_target_package_names(target_dir)
+
+        self.assertIn("target_repo", package_names)
+        self.assertIn("std_msgs", package_names)
+
+    def test_prunes_known_non_target_artifacts_from_publish_install(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            target_dir = root / "src" / "target_repo"
+            (target_dir / "my_pkg" / "msg").mkdir(parents=True)
+            (target_dir / "my_pkg" / "msg" / "Thing.msg").write_text(
+                "string data\n",
+                encoding="utf-8",
+            )
+            (target_dir / "my_lib").mkdir(parents=True)
+            (target_dir / "my_lib" / "CMakeLists.txt").write_text(
+                "project(my_lib)\n",
+                encoding="utf-8",
+            )
+            other_repo = root / "src" / "other_repo"
+            (other_repo / "dependency_lib").mkdir(parents=True)
+            (other_repo / "dependency_lib" / "CMakeLists.txt").write_text(
+                "project(dependency_lib)\n",
+                encoding="utf-8",
+            )
+
+            install_dir = root / "release" / "install" / "target_repo"
+            for rel_root in ("messages", "generated/include", "include"):
+                (install_dir / rel_root / "my_pkg").mkdir(parents=True)
+                (install_dir / rel_root / "std_msgs").mkdir(parents=True)
+            (install_dir / "include" / "my_lib").mkdir(parents=True)
+            (install_dir / "include" / "dependency_lib").mkdir(parents=True)
+            (install_dir / "include" / "external_runtime_headers").mkdir(parents=True)
+            (install_dir / "include" / "raisin_serialization_base.hpp").write_text(
+                "// keep root files\n",
+                encoding="utf-8",
+            )
+
+            _prune_non_target_publish_artifacts(target_dir, install_dir)
+
+            self.assertTrue((install_dir / "messages" / "my_pkg").is_dir())
+            self.assertTrue((install_dir / "generated" / "include" / "my_pkg").is_dir())
+            self.assertTrue((install_dir / "include" / "my_pkg").is_dir())
+            self.assertTrue((install_dir / "include" / "my_lib").is_dir())
+            self.assertTrue(
+                (install_dir / "include" / "external_runtime_headers").is_dir()
+            )
+            self.assertTrue(
+                (install_dir / "include" / "raisin_serialization_base.hpp").is_file()
+            )
+            self.assertFalse((install_dir / "messages" / "std_msgs").exists())
+            self.assertFalse(
+                (install_dir / "generated" / "include" / "std_msgs").exists()
+            )
+            self.assertFalse((install_dir / "include" / "std_msgs").exists())
+            self.assertFalse((install_dir / "include" / "dependency_lib").exists())
+
+    def test_publish_cmake_prefix_path_includes_installed_dependencies(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            old_values = (
+                g.script_directory,
+                g.os_type,
+                g.os_version,
+                g.architecture,
+            )
+            g.script_directory = str(root)
+            g.os_type = "ubuntu"
+            g.os_version = "24.04"
+            g.architecture = "x86_64"
+            try:
+                target_install = (
+                    root
+                    / "release"
+                    / "install"
+                    / "target_repo"
+                    / "ubuntu"
+                    / "24.04"
+                    / "x86_64"
+                    / "release"
+                )
+                dependency_install = (
+                    root
+                    / "release"
+                    / "install"
+                    / "dependency_repo"
+                    / "ubuntu"
+                    / "24.04"
+                    / "x86_64"
+                    / "release"
+                )
+                stale_target_install = (
+                    root
+                    / "release"
+                    / "install"
+                    / "target_repo"
+                    / "ubuntu"
+                    / "24.04"
+                    / "x86_64"
+                    / "debug"
+                )
+                dependency_install.mkdir(parents=True)
+                stale_target_install.mkdir(parents=True)
+
+                prefix_path = _get_publish_cmake_prefix_path(
+                    "target_repo",
+                    "release",
+                    target_install,
+                ).split(";")
+
+            finally:
+                (
+                    g.script_directory,
+                    g.os_type,
+                    g.os_version,
+                    g.architecture,
+                ) = old_values
+
+        self.assertEqual(str(root / "install"), prefix_path[0])
+        self.assertEqual(str(target_install), prefix_path[1])
+        self.assertIn(str(dependency_install), prefix_path)
+        self.assertNotIn(str(stale_target_install), prefix_path)
+
+    def test_missing_publish_dependencies_require_release_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            old_values = (
+                g.script_directory,
+                g.os_type,
+                g.os_version,
+                g.architecture,
+            )
+            g.script_directory = str(root)
+            g.os_type = "ubuntu"
+            g.os_version = "24.04"
+            g.architecture = "x86_64"
+            try:
+                dependency_install = (
+                    root
+                    / "release"
+                    / "install"
+                    / "dependency_repo"
+                    / "ubuntu"
+                    / "24.04"
+                    / "x86_64"
+                    / "release"
+                )
+                dependency_install.mkdir(parents=True)
+
+                missing_before = _get_missing_publish_dependencies(
+                    {"dependencies": ["dependency_repo>=1.0.0"]},
+                    "release",
+                )
+                (dependency_install / "release.yaml").write_text(
+                    "version: 1.0.0\n",
+                    encoding="utf-8",
+                )
+                missing_after = _get_missing_publish_dependencies(
+                    {"dependencies": ["dependency_repo>=1.0.0"]},
+                    "release",
+                )
+
+            finally:
+                (
+                    g.script_directory,
+                    g.os_type,
+                    g.os_version,
+                    g.architecture,
+                ) = old_values
+
+        self.assertEqual(1, len(missing_before))
+        self.assertEqual("dependency_repo>=1.0.0", missing_before[0][0])
+        self.assertEqual([], missing_after)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

This fixes publish artifact contents after the behavior introduced by 244fade, where setup began generating interfaces for every package under src. That behavior is still useful during build because generated headers use relative references to other generated message packages, but it caused individual publish archives to include unrelated message/header artifacts from other repos.

The PR keeps setup/build behavior compatible and instead prunes the staged publish install tree after build/install completes. Non-target generated interface packages are removed from messages/ and generated/include/. The include/ tree is also pruned for directories that are known to belong to non-target source packages, so pure headers from other src repos do not get bundled into the target repo artifact.

Publish now validates that release.yaml dependencies are installed as release artifacts before configuring CMake. Configure also receives a CMAKE_PREFIX_PATH containing the normal install prefix, the current target install prefix, and installed release dependency prefixes from release/install. That lets dry-run and publish builds resolve dependency package configs from installed release artifacts instead of accidentally relying on unrelated local src state.

The pruning remains ownership-aware rather than deleting every unknown include directory: target package include dirs and root files are preserved, and arbitrary external/vcpkg-style include dirs are not removed unless they correspond to a known non-target source package.

## Why

Publishing a single repo should not ship artifacts owned by other repos. Those dependencies should remain dependencies resolved through release.yaml, not be silently bundled from whatever happens to be in the current src checkout.

## Validation

- pytest -q test_publish_artifact_pruning.py
- Direct package discovery check for src/raisin_ros2_messages includes std_msgs and sensor_msgs.
- Direct dependency preflight check for raisin_plugin reports missing release/install artifacts before CMake configure in this workspace.
- Commit hook checks passed, including black and detect-secrets.
