### PR TITLE
fix: guard generated config find_package with TARGET check

### DIFF
--- a/cmake/raisin_helper.cmake
+++ b/cmake/raisin_helper.cmake
@@ -57,7 +57,7 @@ function(raisin_install PROJECT_NAME)
     set(find_package_string "")
     # Loop over the *remaining* arguments, which are the dependencies
     foreach(libName IN LISTS ARG_UNPARSED_ARGUMENTS)
-        string(APPEND find_package_string "find_package(${libName} REQUIRED)\n")
+        string(APPEND find_package_string "if(NOT TARGET ${libName})\n    find_package(${libName} REQUIRED)\nendif()\n")
     endforeach()
 
     set(_package_config_in_content


### PR DESCRIPTION
<img width="782" height="201" alt="image" src="https://github.com/user-attachments/assets/2a265751-c3a9-445f-b842-a73c812c8733" />
