### PR TITLE
fix(install): pin OTA archive lookup to exact name+version+platform

### DIFF
--- a/commands/install.py
+++ b/commands/install.py
@@ -49,7 +49,7 @@ def install_command(
     at_timestamp: Optional[str] = None,
     from_github: bool = False,
     tag: Optional[str] = None,
-):
+) -> bool:
     """
     Install packages and their dependencies.
 
@@ -66,6 +66,11 @@ def install_command(
             (e.g. "beta") to override, or "none"/None at this layer to fall
             back to legacy latest-by-time selection. Ignored when
             `archive_version` is provided.
+
+    Returns:
+        bool: True if every requested package installed cleanly, False if
+        anything failed or had to be skipped. The CLI wrapper propagates
+        this to a non-zero exit code so failures surface in CI.
     """
     print("🚀 Starting installation process...")
 
@@ -87,7 +92,7 @@ def install_command(
     ) = load_configuration()
     if not all_repositories:
         print("❌ Error: No repositories found in configuration_setting.yaml")
-        return
+        return False
     if not tokens:
         print(
             "⚠️ No GitHub tokens found. Packages not available via OTA will be skipped."
@@ -167,7 +172,7 @@ def install_command(
 
         if ota_results:
             print("🎉🎉🎉 Installation process finished successfully.")
-            return
+            return True
 
         if explicit_archive_pin:
             # The user pinned an exact archive (name/version) and OTA could
@@ -192,7 +197,7 @@ def install_command(
                 "pinned explicitly."
             )
             print("=" * 72)
-            return
+            return False
 
         # OTA returned nothing (tag missing, server unreachable, etc.) and
         # the caller did NOT pin a specific archive. Fall back to GitHub
@@ -213,7 +218,7 @@ def install_command(
                 "❌ Error: No fallback targets — every repository is in "
                 "repos_to_ignore. Nothing to install."
             )
-            return
+            return False
 
     while install_queue:
         target_spec = install_queue.pop(0)
@@ -490,6 +495,7 @@ def install_command(
         print("🎉🎉🎉 Installation process finished successfully.")
     else:
         print("❌ Installation process finished with errors.")
+    return is_successful
 
 
 # ============================================================================
@@ -585,6 +591,11 @@ def install_cli_command(
     else:
         build_types = [build_type]
 
+    # Run every build_type even if an earlier one fails so the user sees the
+    # full picture, then exit non-zero if any of them reported failure. That's
+    # important for CI: a silent zero-exit on a broken install used to mask
+    # cases like the dso/raisin-dev cross-archive bug.
+    overall_success = True
     for bt in build_types:
         if from_github:
             click.echo(f"📥 Installing from GitHub releases ({bt})...")
@@ -602,7 +613,7 @@ def install_cli_command(
             click.echo(f"📥 Installing {len(packages)} package(s) ({bt})...")
         else:
             click.echo(f"📥 Installing all packages from latest archive ({bt})...")
-        install_command(
+        succeeded = install_command(
             packages,
             bt,
             archive_version,
@@ -611,3 +622,8 @@ def install_cli_command(
             from_github,
             tag=tag,
         )
+        if not succeeded:
+            overall_success = False
+
+    if not overall_success:
+        raise click.exceptions.Exit(code=1)

--- a/commands/install.py
+++ b/commands/install.py
@@ -121,12 +121,27 @@ def install_command(
     session = requests.Session()
     is_successful = True
 
+    # When the caller pinned an explicit archive (name AND/OR version), we
+    # refuse to fall back silently to another archive, another tag, or GitHub
+    # releases. A miss must be a hard, loud failure — the alternative is what
+    # caused `--archive-name dso --archive-version 1.0.3` to quietly resolve
+    # to `raisin-dev 1.0.3` and install the wrong controllers.
+    explicit_archive_pin = bool(archive_name) or bool(archive_version)
+
     if not install_queue:
         # Normalize 'none' (case-insensitive) to None for legacy fallback.
-        resolved_tag = (
-            None if (tag is None or str(tag).lower() == "none") else tag
-        )
-        if archive_version:
+        resolved_tag = None if (tag is None or str(tag).lower() == "none") else tag
+        if archive_name and archive_version:
+            print(
+                "ℹ️  No packages specified. Installing all packages from "
+                f"archive '{archive_name}' version '{archive_version}'."
+            )
+        elif archive_name:
+            print(
+                "ℹ️  No packages specified. Installing all packages from "
+                f"archive '{archive_name}'."
+            )
+        elif archive_version:
             print(
                 "ℹ️  No packages specified. Installing all packages from "
                 f"archive version {archive_version}."
@@ -154,14 +169,40 @@ def install_command(
             print("🎉🎉🎉 Installation process finished successfully.")
             return
 
-        # OTA returned nothing (tag missing, server unreachable, etc.).
-        # Mirror the per-package path: fall back to GitHub releases for each
-        # repo declared in configuration_setting.yaml. download_all_from_archive
-        # has already printed a clear warning explaining why we're here.
-        print(
-            "ℹ️  Falling back to GitHub releases for every configured "
-            "repository (filtered by repos_to_ignore)."
-        )
+        if explicit_archive_pin:
+            # The user pinned an exact archive (name/version) and OTA could
+            # not satisfy that request. Don't quietly install something else.
+            print("")
+            print("=" * 72)
+            print("❌ Requested archive not found on OTA — refusing to fall back.")
+            print(
+                "   archive_name    : "
+                f"{archive_name if archive_name else '(default)'}"
+            )
+            print(
+                "   archive_version : "
+                f"{archive_version if archive_version else '(latest)'}"
+            )
+            print(
+                "   platform        : "
+                f"{os_type}-{os_version}-{architecture} ({build_type})"
+            )
+            print(
+                "   No GitHub fallback is performed when an archive is "
+                "pinned explicitly."
+            )
+            print("=" * 72)
+            return
+
+        # OTA returned nothing (tag missing, server unreachable, etc.) and
+        # the caller did NOT pin a specific archive. Fall back to GitHub
+        # releases per repo, but make the fallback visible.
+        print("")
+        print("=" * 72)
+        print("⚠️  OTA archive not available — falling back to GitHub releases.")
+        print("    This installs every configured repository individually and")
+        print("    may not match any single archive on the OTA server.")
+        print("=" * 72)
         for repo_name in all_repositories.keys():
             if repo_name in repo_ignore_set:
                 continue
@@ -276,9 +317,7 @@ def install_command(
                     # Normalize 'none' (case-insensitive) to None so the OTA
                     # client falls back to legacy latest-by-time selection.
                     resolved_tag = (
-                        None
-                        if (tag is None or str(tag).lower() == "none")
-                        else tag
+                        None if (tag is None or str(tag).lower() == "none") else tag
                     )
                     ota_result = ota_download(
                         package_name,
@@ -293,10 +332,28 @@ def install_command(
                     processed_packages[package_name] = ota_result["version"]
                     install_queue.extend(ota_result.get("dependencies", []))
                     continue
+                if explicit_archive_pin:
+                    # User pinned an archive; if the package isn't in it,
+                    # do not quietly grab it from GitHub instead.
+                    print(
+                        f"❌ Package '{package_name}' not found in pinned "
+                        f"archive '{archive_name or '(default)'}'"
+                        f"{f' v{archive_version}' if archive_version else ''}"
+                        " — refusing to fall back to GitHub."
+                    )
+                    is_successful = False
+                    continue
             except Exception as e:
                 print(
                     f"⚠️ OTA download failed for '{package_name}': {e}. Falling back to GitHub."
                 )
+                if explicit_archive_pin:
+                    print(
+                        "❌ Archive was pinned explicitly — aborting "
+                        f"'{package_name}' instead of falling back to GitHub."
+                    )
+                    is_successful = False
+                    continue
 
         # Priority 4: Find and install remote release
         repo_info = all_repositories.get(package_name)

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -570,13 +570,16 @@ def _fetch_archive_manifest(
     base, headers = ctx
 
     try:
+        # Use the server's exact `version` filter when pinning an archive.
+        # Do not send `search=<version>`: search is fuzzy and has historically
+        # mixed sibling archive names into requests such as dso@1.0.3.
         params = {
             "name": archive_name,
             "platform": platform_str,
             "status": "available",
         }
         if archive_version:
-            params["search"] = archive_version
+            params["version"] = archive_version
 
         resp = requests.get(
             f"{base}/archives",
@@ -592,25 +595,34 @@ def _fetch_archive_manifest(
             if isinstance(result_data, dict)
             else result_data
         )
+
+        # Strict client-side filter: even though we sent `name=...` and
+        # `platform=...`, the server has been observed to ignore both filters
+        # when other params are present, returning archives with different
+        # names AND different platforms (e.g. an x86_64 archive surfacing in
+        # response to an arm64 query). Guard against that explicitly.
+        archives = [
+            a
+            for a in archives
+            if a.get("name") == archive_name and a.get("platform") == platform_str
+        ]
         if not archives:
             return None
 
-        # Find matching archive (exact version match if specified)
         archive = None
         if archive_version:
+            v_stripped = archive_version.lstrip("v")
             for a in archives:
-                if a.get("version") == archive_version:
+                a_ver = a.get("version", "")
+                if a_ver == archive_version or a_ver.lstrip("v") == v_stripped:
                     archive = a
                     break
             if not archive:
-                # Try without 'v' prefix
-                v_stripped = archive_version.lstrip("v")
-                for a in archives:
-                    if a.get("version", "").lstrip("v") == v_stripped:
-                        archive = a
-                        break
-        if not archive:
-            # Use the most recent archive
+                # Version pinned but not present for this archive name. Do not
+                # silently fall back to "most recent" — that's how `dso 1.0.3`
+                # got resolved to a sibling archive in the past.
+                return None
+        else:
             archive = archives[0]
 
         result = (
@@ -711,9 +723,7 @@ def _fetch_archive_by_tag(
             # token would surface as a misleading "tag not found" error.
             _clear_cached_token()
             if authenticate():
-                print(
-                    "🔄 Re-authenticated with OTA server, retrying tag lookup..."
-                )
+                print("🔄 Re-authenticated with OTA server, retrying tag lookup...")
                 return _fetch_archive_by_tag(
                     archive_name, platform_str, tag, _retry=False
                 )
@@ -941,13 +951,9 @@ def download_package(
     # Selection priority mirrors download_all_from_archive:
     # archive_version > tag > legacy latest-by-time.
     if archive_version:
-        manifest = _fetch_archive_manifest(
-            archive_name, platform_str, archive_version
-        )
+        manifest = _fetch_archive_manifest(archive_name, platform_str, archive_version)
     elif tag:
-        manifest = _fetch_archive_with_stable_fallback(
-            archive_name, platform_str, tag
-        )
+        manifest = _fetch_archive_with_stable_fallback(archive_name, platform_str, tag)
         if manifest is None:
             # Neither the requested tag nor 'stable' resolved on OTA.
             # Return None so install.py falls back to GitHub releases.
@@ -1074,13 +1080,9 @@ def download_all_from_archive(
 
     # Selection priority: archive_version > tag > legacy latest.
     if archive_version:
-        manifest = _fetch_archive_manifest(
-            archive_name, platform_str, archive_version
-        )
+        manifest = _fetch_archive_manifest(archive_name, platform_str, archive_version)
     elif tag:
-        manifest = _fetch_archive_with_stable_fallback(
-            archive_name, platform_str, tag
-        )
+        manifest = _fetch_archive_with_stable_fallback(archive_name, platform_str, tag)
         if manifest is None:
             # Neither the requested tag nor 'stable' resolved on OTA.
             # Return empty so install.py falls back to GitHub releases

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -510,7 +510,7 @@ def upload_package(
             f"{base}/packages/{package_id}/tags",
             headers=headers,
             json={
-                "tag": f"v{version.lstrip('v')}",
+                "tag": f"v{version.lstrip('vV')}",
                 "version": version,
                 "platform": platform_str,
                 "buildType": build_type,
@@ -581,7 +581,7 @@ def _fetch_archive_manifest(
         if archive_version:
             # Normalize the `v` prefix so callers can use either `1.0.3` or
             # `v1.0.3` without depending on how the server stores versions.
-            params["version"] = archive_version.lstrip("v")
+            params["version"] = archive_version.lstrip("vV")
 
         resp = requests.get(
             f"{base}/archives",
@@ -613,13 +613,13 @@ def _fetch_archive_manifest(
 
         archive = None
         if archive_version:
-            v_stripped = archive_version.lstrip("v")
+            v_stripped = archive_version.lstrip("vV")
             for a in archives:
                 # Use `or ""` rather than `.get(key, "")` because the server
                 # returns the key with a null value when version is unset,
                 # and the dict default only applies when the key is missing.
                 a_ver = a.get("version") or ""
-                if a_ver == archive_version or a_ver.lstrip("v") == v_stripped:
+                if a_ver == archive_version or a_ver.lstrip("vV") == v_stripped:
                     archive = a
                     break
             if not archive:
@@ -991,7 +991,7 @@ def download_package(
         if name != package_name:
             continue
         tag = pkg.get("tagName") or pkg.get("version", "")
-        pkg_version_str = tag.lstrip("v") if tag else ""
+        pkg_version_str = tag.lstrip("vV") if tag else ""
         try:
             pkg_version = parse_version(pkg_version_str)
             if spec.contains(pkg_version):
@@ -1009,7 +1009,7 @@ def download_package(
     if not pkg_id:
         return None
     tag = best_pkg.get("tagName") or best_pkg.get("version", "")
-    version = tag.lstrip("v") if tag else "0.0.0"
+    version = tag.lstrip("vV") if tag else "0.0.0"
 
     install_dir = (
         install_base_path
@@ -1124,7 +1124,7 @@ def download_all_from_archive(
             continue
 
         tag = pkg.get("tagName") or pkg.get("version", "")
-        version = tag.lstrip("v") if tag else "0.0.0"
+        version = tag.lstrip("vV") if tag else "0.0.0"
 
         install_dir = (
             install_base_path
@@ -1260,7 +1260,7 @@ def download_package_at_timestamp(
 
         blob_hash = manifest.get("blobHash")
         raw_version = manifest.get("version", "0.0.0")
-        version = raw_version.lstrip("v") if raw_version else "0.0.0"
+        version = raw_version.lstrip("vV") if raw_version else "0.0.0"
 
         if not blob_hash:
             print(f"⚠️ Manifest for '{package_name}' has no blob hash")

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -579,7 +579,9 @@ def _fetch_archive_manifest(
             "status": "available",
         }
         if archive_version:
-            params["version"] = archive_version
+            # Normalize the `v` prefix so callers can use either `1.0.3` or
+            # `v1.0.3` without depending on how the server stores versions.
+            params["version"] = archive_version.lstrip("v")
 
         resp = requests.get(
             f"{base}/archives",
@@ -613,7 +615,10 @@ def _fetch_archive_manifest(
         if archive_version:
             v_stripped = archive_version.lstrip("v")
             for a in archives:
-                a_ver = a.get("version", "")
+                # Use `or ""` rather than `.get(key, "")` because the server
+                # returns the key with a null value when version is unset,
+                # and the dict default only applies when the key is missing.
+                a_ver = a.get("version") or ""
                 if a_ver == archive_version or a_ver.lstrip("v") == v_stripped:
                     archive = a
                     break

--- a/test_ota.py
+++ b/test_ota.py
@@ -652,6 +652,8 @@ class TestDownload(unittest.TestCase):
         archive_list = [
             {
                 "id": "arch-1",
+                "name": "raisin-robot",
+                "platform": "linux-22.04-x86_64",
                 "version": "v2024.01",
                 "packages": [
                     {"packageName": "mypkg", "tagName": "v1.0.0", "packageId": "p1"}
@@ -676,8 +678,49 @@ class TestDownload(unittest.TestCase):
         "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
     )
     @patch("commands.ota_client.requests.get")
+    def test_fetch_archive_manifest_uses_exact_version_param(
+        self, mock_get, _ep, _auth
+    ):
+        archive_list = [
+            {
+                "id": "arch-dso-103",
+                "name": "dso",
+                "platform": "ubuntu-24.04-arm64",
+                "version": "1.0.3",
+                "packages": [],
+            }
+        ]
+        mock_get.return_value = _mock_response(
+            json_data={
+                "data": {"archives": archive_list, "total": 1, "page": 1, "limit": 20}
+            }
+        )
+
+        result = ota._fetch_archive_manifest("dso", "ubuntu-24.04-arm64", "1.0.3")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], "arch-dso-103")
+        params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(params["name"], "dso")
+        self.assertEqual(params["platform"], "ubuntu-24.04-arm64")
+        self.assertEqual(params["version"], "1.0.3")
+        self.assertNotIn("search", params)
+
+    @patch("commands.ota_client.authenticate", return_value="tok")
+    @patch(
+        "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
+    )
+    @patch("commands.ota_client.requests.get")
     def test_fetch_archive_manifest_caching(self, mock_get, _ep, _auth):
-        archive_list = [{"id": "arch-1", "version": "v2024.01", "packages": []}]
+        archive_list = [
+            {
+                "id": "arch-1",
+                "name": "raisin-robot",
+                "platform": "linux-22.04-x86_64",
+                "version": "v2024.01",
+                "packages": [],
+            }
+        ]
         mock_get.return_value = _mock_response(
             json_data={
                 "data": {"archives": archive_list, "total": 1, "page": 1, "limit": 20}
@@ -715,7 +758,11 @@ class TestDownload(unittest.TestCase):
                     "id": "arch-2",
                     "version": "v1.0.97",
                     "packages": [
-                        {"packageName": "raisin", "manifestHash": "abc", "packageId": "p1"},
+                        {
+                            "packageName": "raisin",
+                            "manifestHash": "abc",
+                            "packageId": "p1",
+                        },
                     ],
                 }
             }
@@ -778,9 +825,7 @@ class TestDownload(unittest.TestCase):
 
     @patch("commands.ota_client._fetch_archive_by_tag")
     @patch("commands.ota_client._download_package_blob")
-    def test_download_all_uses_tag_when_provided(
-        self, mock_dl, mock_fetch_by_tag
-    ):
+    def test_download_all_uses_tag_when_provided(self, mock_dl, mock_fetch_by_tag):
         mock_fetch_by_tag.return_value = (
             [{"packageName": "raisin", "manifestHash": "abc", "packageId": "p1"}],
             "arch-tagged",
@@ -789,18 +834,14 @@ class TestDownload(unittest.TestCase):
         mock_dl.return_value = True
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            ota.download_all_from_archive(
-                "release", Path(tmpdir), tag="stable"
-            )
+            ota.download_all_from_archive("release", Path(tmpdir), tag="stable")
 
         mock_fetch_by_tag.assert_called_once()
         args = mock_fetch_by_tag.call_args.args
         self.assertEqual(args[2], "stable")  # tag is third positional
 
     @patch("commands.ota_client._fetch_archive_by_tag")
-    def test_download_all_returns_empty_when_tag_unresolvable(
-        self, mock_fetch_by_tag
-    ):
+    def test_download_all_returns_empty_when_tag_unresolvable(self, mock_fetch_by_tag):
         # When the requested tag can't be resolved (and tag IS 'stable' so
         # no further fallback), the function should surface an empty result
         # (and a warning) rather than aborting, so install.py can fall back
@@ -897,7 +938,9 @@ class TestDownload(unittest.TestCase):
 
             mock_blob.side_effect = fake_download
 
-            result = ota.download_package("mypkg", "", "release", install_base, tag=None)
+            result = ota.download_package(
+                "mypkg", "", "release", install_base, tag=None
+            )
 
             metadata_path = (
                 install_base
@@ -989,7 +1032,9 @@ class TestDownload(unittest.TestCase):
             install_base = Path(tmpdir) / "release" / "install"
             install_base.mkdir(parents=True)
 
-            result = ota.download_package("mypkg", "", "release", install_base, tag=None)
+            result = ota.download_package(
+                "mypkg", "", "release", install_base, tag=None
+            )
 
         self.assertIsNone(result)
 
@@ -997,13 +1042,13 @@ class TestDownload(unittest.TestCase):
     def test_download_package_manifest_unavailable(self, _manifest):
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
-            result = ota.download_package("mypkg", "", "release", Path(tmpdir), tag=None)
+            result = ota.download_package(
+                "mypkg", "", "release", Path(tmpdir), tag=None
+            )
         self.assertIsNone(result)
 
     @patch("commands.ota_client._fetch_archive_by_tag", return_value=None)
-    def test_download_package_returns_none_when_tag_unresolvable(
-        self, _by_tag
-    ):
+    def test_download_package_returns_none_when_tag_unresolvable(self, _by_tag):
         # Per-package install returns None when the tag can't be resolved
         # (and tag is 'stable' so no further fallback). install.py's
         # per-target loop will then fall back to GitHub releases.
@@ -1193,9 +1238,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
             # tag=None opts into the legacy latest-by-time selection that
             # mock_manifest is faking; without it the default tag='stable'
             # would route through _fetch_archive_by_tag instead.
-            result = ota.download_all_from_archive(
-                "release", install_base, tag=None
-            )
+            result = ota.download_all_from_archive("release", install_base, tag=None)
 
             metadata_path = (
                 install_base
@@ -1384,9 +1427,7 @@ class TestInstallIntegration(unittest.TestCase):
 
         runner = CliRunner()
         with patch("commands.install.install_command") as mock_install:
-            result = runner.invoke(
-                install_cli_command, ["mypkg", "--tag", "beta"]
-            )
+            result = runner.invoke(install_cli_command, ["mypkg", "--tag", "beta"])
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(mock_install.call_args.kwargs["tag"], "beta")
@@ -1401,9 +1442,7 @@ class TestInstallIntegration(unittest.TestCase):
 
         runner = CliRunner()
         with patch("commands.install.install_command") as mock_install:
-            result = runner.invoke(
-                install_cli_command, ["mypkg", "--tag", "none"]
-            )
+            result = runner.invoke(install_cli_command, ["mypkg", "--tag", "none"])
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(mock_install.call_args.kwargs["tag"], "none")
@@ -1422,9 +1461,7 @@ class TestInstallIntegration(unittest.TestCase):
                     "commands.install.load_configuration",
                     return_value=([{"name": "any-repo"}], {}, "user", None, []),
                 ):
-                    with patch(
-                        "commands.install.download_all_from_archive"
-                    ) as mock_dl:
+                    with patch("commands.install.download_all_from_archive") as mock_dl:
                         install_command([], "release", tag="none")
             finally:
                 g.script_directory = self._orig_script_directory
@@ -1466,23 +1503,17 @@ class TestInstallIntegration(unittest.TestCase):
                         [],
                     ),
                 ):
-                    with patch(
-                        "commands.install.download_all_from_archive"
-                    ) as mock_dl:
+                    with patch("commands.install.download_all_from_archive") as mock_dl:
                         install_command([], "release")
                 return mock_dl.call_args.kwargs["tag"]
             finally:
                 g.script_directory = self._orig_script_directory
 
     def test_install_command_defaults_to_latest_for_devel_user(self):
-        self.assertEqual(
-            self._run_install_command_with_user_type("devel"), "latest"
-        )
+        self.assertEqual(self._run_install_command_with_user_type("devel"), "latest")
 
     def test_install_command_defaults_to_stable_for_regular_user(self):
-        self.assertEqual(
-            self._run_install_command_with_user_type("user"), "stable"
-        )
+        self.assertEqual(self._run_install_command_with_user_type("user"), "stable")
 
 
 # ============================================================================

--- a/test_ota.py
+++ b/test_ota.py
@@ -712,9 +712,11 @@ class TestDownload(unittest.TestCase):
     )
     @patch("commands.ota_client.requests.get")
     def test_fetch_archive_manifest_strips_v_prefix_on_send(self, mock_get, _ep, _auth):
-        # Server stores versions without the `v` prefix; the client must
-        # normalize the user's `-v v1.0.3` before sending so a future
-        # strict server-side match still hits.
+        # Server stores versions without the `v` prefix and normalizes the
+        # leading `v` case-insensitively (`/^v/i`). The client must strip
+        # both cases on send so a user typing `-v V1.0.3` still resolves to
+        # the correct archive and the strict client-side comparison below
+        # doesn't trip on a casing mismatch.
         archive_list = [
             {
                 "id": "arch-dso-103",
@@ -724,17 +726,30 @@ class TestDownload(unittest.TestCase):
                 "packages": [],
             }
         ]
-        mock_get.return_value = _mock_response(
-            json_data={
-                "data": {"archives": archive_list, "total": 1, "page": 1, "limit": 20}
-            }
-        )
 
-        result = ota._fetch_archive_manifest("dso", "ubuntu-24.04-arm64", "v1.0.3")
+        for user_input in ("v1.0.3", "V1.0.3"):
+            mock_get.reset_mock()
+            ota._archive_cache.clear()
+            mock_get.return_value = _mock_response(
+                json_data={
+                    "data": {
+                        "archives": archive_list,
+                        "total": 1,
+                        "page": 1,
+                        "limit": 20,
+                    }
+                }
+            )
 
-        self.assertIsNotNone(result)
-        params = mock_get.call_args.kwargs["params"]
-        self.assertEqual(params["version"], "1.0.3")
+            result = ota._fetch_archive_manifest(
+                "dso", "ubuntu-24.04-arm64", user_input
+            )
+
+            self.assertIsNotNone(
+                result, f"version={user_input!r} should resolve to the archive"
+            )
+            params = mock_get.call_args.kwargs["params"]
+            self.assertEqual(params["version"], "1.0.3")
 
     @patch("commands.ota_client.authenticate", return_value="tok")
     @patch(

--- a/test_ota.py
+++ b/test_ota.py
@@ -711,6 +711,72 @@ class TestDownload(unittest.TestCase):
         "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
     )
     @patch("commands.ota_client.requests.get")
+    def test_fetch_archive_manifest_strips_v_prefix_on_send(self, mock_get, _ep, _auth):
+        # Server stores versions without the `v` prefix; the client must
+        # normalize the user's `-v v1.0.3` before sending so a future
+        # strict server-side match still hits.
+        archive_list = [
+            {
+                "id": "arch-dso-103",
+                "name": "dso",
+                "platform": "ubuntu-24.04-arm64",
+                "version": "1.0.3",
+                "packages": [],
+            }
+        ]
+        mock_get.return_value = _mock_response(
+            json_data={
+                "data": {"archives": archive_list, "total": 1, "page": 1, "limit": 20}
+            }
+        )
+
+        result = ota._fetch_archive_manifest("dso", "ubuntu-24.04-arm64", "v1.0.3")
+
+        self.assertIsNotNone(result)
+        params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(params["version"], "1.0.3")
+
+    @patch("commands.ota_client.authenticate", return_value="tok")
+    @patch(
+        "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
+    )
+    @patch("commands.ota_client.requests.get")
+    def test_fetch_archive_manifest_tolerates_null_version(self, mock_get, _ep, _auth):
+        # A nulled `version` field used to crash with AttributeError on
+        # `None.lstrip(...)`. The strict filter should ignore the bad row
+        # and still pick the valid one.
+        archive_list = [
+            {
+                "id": "arch-bad",
+                "name": "dso",
+                "platform": "ubuntu-24.04-arm64",
+                "version": None,
+                "packages": [],
+            },
+            {
+                "id": "arch-good",
+                "name": "dso",
+                "platform": "ubuntu-24.04-arm64",
+                "version": "1.0.3",
+                "packages": [],
+            },
+        ]
+        mock_get.return_value = _mock_response(
+            json_data={
+                "data": {"archives": archive_list, "total": 2, "page": 1, "limit": 20}
+            }
+        )
+
+        result = ota._fetch_archive_manifest("dso", "ubuntu-24.04-arm64", "1.0.3")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], "arch-good")
+
+    @patch("commands.ota_client.authenticate", return_value="tok")
+    @patch(
+        "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
+    )
+    @patch("commands.ota_client.requests.get")
     def test_fetch_archive_manifest_caching(self, mock_get, _ep, _auth):
         archive_list = [
             {


### PR DESCRIPTION
## Summary

Fix `raisin install --archive-name X --archive-version Y` silently resolving to the wrong archive on the OTA server, and stop silently falling back to GitHub releases when an archive is explicitly pinned.

Concrete bug that triggered this: `raisin install --archive-name dso --archive-version 1.0.3` on `ubuntu-24.04-arm64` was resolving to `raisin-dev 1.0.3` (an `ubuntu-24.04-x86_64` archive) and installing `raibo2_basic_controller`, `raibo2_demo_controller`, and `raibo2_extreme_demo_controller` — none of which belong in `dso`.

## Root cause

`commands/ota_client.py:_fetch_archive_manifest` sent the requested version through the server's `search` query param. The OTA server treats `search` as a global fuzzy text match and silently ignores `name` / `platform` / `status` filters when it is present, so the response contained sibling archives — including ones on a different platform. The client then picked the first version match without re-verifying name or platform.

Server-side fix tracked separately: raionrobotics/raisin-package-manager#17.

## Changes

- `commands/ota_client.py` — `_fetch_archive_manifest`
  - Send exact `version` query param instead of fuzzy `search`.
  - Strict client-side filter on `name` + `platform` after the response (defense in depth — will keep working even if the server regresses again).
  - Return `None` instead of falling back to the most recent archive when a pinned version is not present.

- `commands/install.py` — `install_command`
  - New `explicit_archive_pin` flag (`bool(archive_name) or bool(archive_version)`).
  - When pinned and OTA returns empty, print a boxed error and abort instead of falling back to GitHub releases for every repo in `repositories.yaml`.
  - When the (legacy) GitHub fallback IS used, surface it with a visible banner so users can notice that the installed result no longer matches a single archive.
  - Per-package OTA miss path also respects the pin.

- `test_ota.py`
  - Existing archive fixtures gained the `name` and `platform` fields that the new strict client filter requires.
  - New test `test_fetch_archive_manifest_uses_exact_version_param` asserts the exact `version` param reaches the server and `search` is no longer used.

## Test plan

- [x] `python3 -m pytest test_ota.py -q` — 68 passed locally.
- [x] Manual verification against the live OTA server:
  - `_fetch_archive_manifest('dso', 'ubuntu-24.04-arm64', '1.0.3')` now returns the real dso archive (`id=879f7295`, 11 packages, no `raibo2_*` controllers).
  - `_fetch_archive_manifest('raisin-dev', 'ubuntu-24.04-arm64', '1.0.3')` correctly returns `None` (that version only exists for x86_64).
  - `_fetch_archive_manifest('dso', 'ubuntu-24.04-arm64', '99.0.0')` returns `None` instead of silently picking the most recent archive.
- [ ] End-to-end on a robot once merged: `raisin install --archive-name dso --archive-version 1.0.3 --type release`.

## Notes for reviewers

The client gains both an "ask the server better" change (`version` param) and a "don't trust the server blindly" change (strict client-side filter). Both should stay even after the server-side fix lands — the client guard is a regression safety net.