### PR TITLE
[M2 client] Robot-authenticated OTA: download, verification, desired state, install reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ cp configuration_setting_example.yaml configuration_setting.yaml
 Next, open **`configuration_setting.yaml`** and edit the following fields:
 * **`gh_tokens`**: (Optional) GitHub Personal Access Token for each organization (e.g., `"raionrobotics": "ghp_your_token"`). Only needed for GitHub fallback or publishing to GitHub.
 * **`user_type`**: Set to `"user"` for stable releases or `"devel"` for development builds.
+* **`robot.api_key`**: (Optional) Robot API key for robot-authenticated OTA downloads. Prefer `RAISIN_ROBOT_API_KEY` for deployments.
+* **`robot.node`**: (Required when using a robot API key) Robot-local node key registered on the OTA server, e.g. `"jetson"` or `"primary"`.
 * **`packages_to_ignore`**: (Optional) List of packages to exclude from the build process.
 * **`repos_to_ignore`**: (Optional) List of repositories to exclude (uses prebuilt binaries instead).
 
@@ -82,6 +84,10 @@ export RAISIN_SSH_KEY="~/.ssh/my_key"
 
 # (Optional) Custom archive name prefix (default: raisin-robot)
 export RAISIN_ARCHIVE_NAME="raisin-robot"
+
+# (Optional) Robot-authenticated OTA downloads and snapshot reporting
+export RAISIN_ROBOT_API_KEY="rk_..."  # pragma: allowlist secret
+export RAISIN_ROBOT_NODE="jetson"
 ```
 
 #### SSH Key Authentication

--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ If `RAISIN_SSH_KEY` is not set, RAISIN auto-detects existing keys in `~/.ssh/` i
 
 > **Note:** Ensure your SSH public key is registered with the OTA server before using OTA features.
 
+#### Robot API Key Authentication
+
+A robot registered on the OTA server can be issued an API key (`rk_<uuid>_<secret>`). When both `RAISIN_ROBOT_API_KEY` and `RAISIN_ROBOT_NODE` are set — or `robot.api_key` and `robot.node` in `configuration_setting.yaml` — the install flow additionally:
+
+- downloads package blobs through the robot-authenticated endpoint, so downloads are attributed to this robot and node;
+- verifies each download against the server's `X-Content-Hash` and aborts on a mismatch;
+- asks the server for this node's **desired state**, honouring an assigned archive target and stopping the install entirely when a halt is in effect;
+- reports an installed-software snapshot after the install so the fleet view reflects what the robot is actually running.
+
+An archive name or version passed explicitly (`--archive-version`, `RAISIN_ARCHIVE_NAME`) is treated as a deliberate pin and takes precedence over the server's desired state.
+
+> **Limitation:** enumerating an archive's packages still requires SSH authentication — the robot-authenticated API exposes no manifest listing for manifest-only archives. A robot provisioned with *only* an API key cannot yet resolve an archive, and will fall back to GitHub releases. Register an SSH key alongside the API key until the server adds a robot-facing manifest endpoint.
+
+The key is read in this order: `RAISIN_ROBOT_API_KEY`, `RAISIN_ROBOT_API_KEY_FILE`, `configuration_setting.yaml`/`secrets.yaml`, then `~/.config/raisin/robot-api-key`. File-backed keys are ignored on POSIX systems unless they are `chmod 600`.
+
 ### 4. Add Source Packages
 
 Create a directory named `src` in the root of the repository. Clone any source code packages you are developing or contributing to inside this `src` directory.

--- a/commands/install.py
+++ b/commands/install.py
@@ -25,7 +25,11 @@ from packaging.specifiers import SpecifierSet
 from commands import globals as g
 from commands.utils import load_configuration, parse_version_specifier
 
-from commands.ota_client import download_package_at_timestamp, download_all_from_archive
+from commands.ota_client import (
+    download_package_at_timestamp,
+    download_all_from_archive,
+    flush_pending_snapshot_reports,
+)
 
 
 def _default_tag_for_user_type(user_type: Optional[str]) -> str:
@@ -624,6 +628,8 @@ def install_cli_command(
         )
         if not succeeded:
             overall_success = False
+
+    flush_pending_snapshot_reports()
 
     if not overall_success:
         raise click.exceptions.Exit(code=1)

--- a/commands/install.py
+++ b/commands/install.py
@@ -522,13 +522,6 @@ def install_command(
     help="Build type to install",
 )
 @click.option(
-    "--all",
-    "-a",
-    "install_all",
-    is_flag=True,
-    help="Install both debug and release builds",
-)
-@click.option(
     "--archive-version",
     "-v",
     "archive_version",
@@ -569,7 +562,6 @@ def install_command(
 def install_cli_command(
     packages,
     build_type,
-    install_all,
     archive_version,
     archive_name,
     at_timestamp,
@@ -585,7 +577,6 @@ def install_cli_command(
         raisin install raisin_network                # Install specific package
         raisin install raisin_network==1.1.0         # Install specific version
         raisin install --type debug                  # Install debug builds
-        raisin install --all                         # Install both debug and release
         raisin install --archive-version v2024.01   # Install from specific archive
         raisin install --archive-name team-robot    # Install from a custom archive name
         raisin install --at 2024-01-15               # Install packages at timestamp
@@ -593,10 +584,7 @@ def install_cli_command(
     """
     packages = list(packages)
 
-    if install_all:
-        build_types = ["debug", "release"]
-    else:
-        build_types = [build_type]
+    build_types = [build_type]
 
     # Run every build_type even if an earlier one fails so the user sees the
     # full picture, then exit non-zero if any of them reported failure. That's

--- a/commands/install.py
+++ b/commands/install.py
@@ -29,6 +29,7 @@ from commands.ota_client import (
     download_package_at_timestamp,
     download_all_from_archive,
     flush_pending_snapshot_reports,
+    clear_install_session,
 )
 
 
@@ -631,5 +632,8 @@ def install_cli_command(
 
     flush_pending_snapshot_reports()
 
+    # Keep the session on failure so a retry resumes it; retire it on success.
     if not overall_success:
         raise click.exceptions.Exit(code=1)
+
+    clear_install_session()

--- a/commands/install.py
+++ b/commands/install.py
@@ -30,7 +30,7 @@ from commands.ota_client import (
     download_all_from_archive,
     flush_pending_snapshot_reports,
     clear_install_session,
-    record_install_event,
+    report_install_outcome,
     flush_install_events,
 )
 
@@ -634,10 +634,10 @@ def install_cli_command(
 
     flush_pending_snapshot_reports()
 
-    # Only the CLI knows the attempt as a whole succeeded; a failure has
-    # already emitted its terminal event where it happened.
-    if overall_success:
-        record_install_event("succeeded")
+    # Close the attempt with one terminal event. A failure noted downstream
+    # outranks overall_success, because install_command returns True when any
+    # package landed — a partial archive install is not a completed one.
+    report_install_outcome(overall_success)
 
     # Flush either way — a failed attempt is exactly what needs reporting.
     flush_install_events()

--- a/commands/install.py
+++ b/commands/install.py
@@ -25,9 +25,12 @@ from packaging.specifiers import SpecifierSet
 from commands import globals as g
 from commands.utils import load_configuration, parse_version_specifier
 
+from commands.install_tree import InstallTreeUnusable
 from commands.ota_client import (
     download_package_at_timestamp,
     download_all_from_archive,
+    OtaInstallHalted,
+    archive_is_pinned,
     flush_pending_snapshot_reports,
     clear_install_session,
     report_install_outcome,
@@ -49,6 +52,43 @@ def _default_tag_for_user_type(user_type: Optional[str]) -> str:
 
 
 def install_command(
+    targets,
+    build_type,
+    archive_version: Optional[str] = None,
+    archive_name: Optional[str] = None,
+    at_timestamp: Optional[str] = None,
+    from_github: bool = False,
+    tag: Optional[str] = None,
+) -> bool:
+    """Install packages, reporting a broken install tree rather than raising.
+
+    Both the archive route and the per-package route prepare the versioned
+    tree, so both can find it unusable — on a robot whose `release/install` is
+    a mount point, for instance. That is a layout problem, not a reason to
+    install the same packages from somewhere else into the same place, so it
+    ends the run here instead of falling through.
+    """
+    try:
+        return _install(
+            targets,
+            build_type,
+            archive_version,
+            archive_name,
+            at_timestamp,
+            from_github,
+            tag,
+        )
+    except InstallTreeUnusable as unusable:
+        print("")
+        print("=" * 72)
+        print("❌ The install tree cannot be prepared — nothing was installed.")
+        print(f"   {unusable}")
+        print("   No fallback is performed; the layout has to change first.")
+        print("=" * 72)
+        return False
+
+
+def _install(
     targets,
     build_type,
     archive_version: Optional[str] = None,
@@ -133,12 +173,12 @@ def install_command(
     session = requests.Session()
     is_successful = True
 
-    # When the caller pinned an explicit archive (name AND/OR version), we
-    # refuse to fall back silently to another archive, another tag, or GitHub
-    # releases. A miss must be a hard, loud failure — the alternative is what
-    # caused `--archive-name dso --archive-version 1.0.3` to quietly resolve
-    # to `raisin-dev 1.0.3` and install the wrong controllers.
-    explicit_archive_pin = bool(archive_name) or bool(archive_version)
+    # When an archive is pinned — on the command line, or per-node through
+    # RAISIN_ARCHIVE_NAME — we refuse to fall back silently to another archive,
+    # another tag, or GitHub releases. A miss must be a hard, loud failure: the
+    # alternative is what caused `--archive-name dso --archive-version 1.0.3`
+    # to quietly resolve to `raisin-dev 1.0.3` and install the wrong controllers.
+    explicit_archive_pin = archive_is_pinned(archive_name, archive_version)
 
     if not install_queue:
         # Normalize 'none' (case-insensitive) to None for legacy fallback.
@@ -169,13 +209,24 @@ def install_command(
                 "the latest archive."
             )
 
-        ota_results = download_all_from_archive(
-            build_type,
-            script_dir_path / "release" / "install",
-            archive_version=archive_version,
-            archive_name=archive_name,
-            tag=resolved_tag,
-        )
+        try:
+            ota_results = download_all_from_archive(
+                build_type,
+                script_dir_path / "release" / "install",
+                archive_version=archive_version,
+                archive_name=archive_name,
+                tag=resolved_tag,
+            )
+        except OtaInstallHalted as halted:
+            # A halt is an instruction to stop. Falling back would install the
+            # same software from somewhere else and call it obedience.
+            print("")
+            print("=" * 72)
+            print("⛔ Installs are halted for this node — nothing was installed.")
+            print(f"   {halted}")
+            print("   No fallback is performed while a halt is in effect.")
+            print("=" * 72)
+            return False
 
         if ota_results:
             print("🎉🎉🎉 Installation process finished successfully.")
@@ -355,6 +406,10 @@ def install_command(
                     )
                     is_successful = False
                     continue
+            except InstallTreeUnusable:
+                # Not a per-package problem, and retrying the next package
+                # against the same broken tree would only repeat it.
+                raise
             except Exception as e:
                 print(
                     f"⚠️ OTA download failed for '{package_name}': {e}. Falling back to GitHub."

--- a/commands/install.py
+++ b/commands/install.py
@@ -30,6 +30,8 @@ from commands.ota_client import (
     download_all_from_archive,
     flush_pending_snapshot_reports,
     clear_install_session,
+    record_install_event,
+    flush_install_events,
 )
 
 
@@ -631,6 +633,14 @@ def install_cli_command(
             overall_success = False
 
     flush_pending_snapshot_reports()
+
+    # Only the CLI knows the attempt as a whole succeeded; a failure has
+    # already emitted its terminal event where it happened.
+    if overall_success:
+        record_install_event("succeeded")
+
+    # Flush either way — a failed attempt is exactly what needs reporting.
+    flush_install_events()
 
     # Keep the session on failure so a retry resumes it; retire it on success.
     if not overall_success:

--- a/commands/install_tree.py
+++ b/commands/install_tree.py
@@ -23,6 +23,7 @@ from typing import List, Optional, Tuple
 _VERSIONS_DIR = "versions"
 _CURRENT_LINK = "install"
 _PREVIOUS_FILE = ".previous-version"
+_SESSION_FILE = ".current-session"
 _LEGACY_VERSION = "legacy"
 
 _GENERATION_RE = re.compile(r"^(\d{4})-(.+)$")
@@ -159,6 +160,27 @@ def _previous_dir_name(release) -> Optional[str]:
     return name
 
 
+def _read_commit_session(release) -> Optional[str]:
+    try:
+        value = (Path(release) / _SESSION_FILE).read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return value or None
+
+
+def _write_commit_session(release, session: Optional[str]) -> None:
+    path = Path(release) / _SESSION_FILE
+    try:
+        if session is None:
+            if path.exists():
+                path.unlink()
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(session, encoding="utf-8")
+    except OSError:
+        pass
+
+
 def _write_previous(release, dir_name: Optional[str]) -> None:
     path = _previous_file(release)
     try:
@@ -253,16 +275,30 @@ def _resolve_version_dir(release, version: str) -> Optional[Path]:
     return matches[-1] if matches else None
 
 
-def commit_version(release, version: str) -> Optional[str]:
-    """Make a staged version live. Returns the directory now current."""
+def commit_version(
+    release, version: str, session: Optional[str] = None
+) -> Optional[str]:
+    """Make a staged version live. Returns the directory now current.
+
+    `session` identifies the install attempt. One attempt can commit more than
+    once — `raisin install --install-all` runs the whole flow per build type —
+    and the rollback target must stay the state that existed *before* the
+    attempt, not the intermediate one the attempt itself produced. Rolling back
+    to that intermediate state would restore a tree that was never good: after
+    the debug pass it holds the new debug binaries and the old release ones.
+    """
     target = _resolve_version_dir(release, version)
     if target is None:
         return None
 
     outgoing = _current_dir_name(release)
+    committed_by = _read_commit_session(release)
     _point_current_at(release, target.name)
-    if outgoing and outgoing != target.name:
+
+    replacing_own_work = bool(session) and session == committed_by
+    if outgoing and outgoing != target.name and not replacing_own_work:
         _write_previous(release, outgoing)
+    _write_commit_session(release, session)
     return target.name
 
 

--- a/commands/install_tree.py
+++ b/commands/install_tree.py
@@ -1,0 +1,310 @@
+"""Versioned install tree with a single atomic commit point.
+
+    release/versions/<gen>-<version>/   one complete package tree
+    release/install -> versions/<gen>-<version>
+
+`release/install` keeps the path every other consumer already uses
+(`repo_dependency_check`, `index`); only its type changes, from a real
+directory to a symlink. Nothing a run produces is live until the symlink moves,
+so a failed install needs no compensation — it simply never commits — and a
+rollback is one atomic operation rather than a sequence of undo steps.
+
+Directories carry a generation prefix so that re-installing the version that is
+already live still stages into a fresh directory instead of mutating the tree
+underneath a running system.
+"""
+
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+_VERSIONS_DIR = "versions"
+_CURRENT_LINK = "install"
+_PREVIOUS_FILE = ".previous-version"
+_LEGACY_VERSION = "legacy"
+
+_GENERATION_RE = re.compile(r"^(\d{4})-(.+)$")
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def release_for(install_path) -> Path:
+    """The release directory that owns a given `.../release/install` path."""
+    return Path(install_path).parent
+
+
+def versions_dir(release) -> Path:
+    return Path(release) / _VERSIONS_DIR
+
+
+def current_link(release) -> Path:
+    return Path(release) / _CURRENT_LINK
+
+
+def _previous_file(release) -> Path:
+    return Path(release) / _PREVIOUS_FILE
+
+
+def _split_generation(name: str) -> Optional[Tuple[int, str]]:
+    match = _GENERATION_RE.match(name)
+    return (int(match.group(1)), match.group(2)) if match else None
+
+
+def _generations(release) -> List[Tuple[int, str, Path]]:
+    """Every staged or committed version directory, oldest generation first."""
+    base = versions_dir(release)
+    if not base.is_dir():
+        return []
+
+    found = []
+    for entry in base.iterdir():
+        if not entry.is_dir():
+            continue
+        parsed = _split_generation(entry.name)
+        if parsed:
+            found.append((parsed[0], parsed[1], entry))
+    return sorted(found, key=lambda item: item[0])
+
+
+def _next_generation(release) -> int:
+    generations = _generations(release)
+    return (generations[-1][0] + 1) if generations else 1
+
+
+def _current_dir_name(release) -> Optional[str]:
+    link = current_link(release)
+    if not link.is_symlink():
+        return None
+
+    name = Path(os.readlink(link)).name
+    # A dangling link means the version was removed underneath us. Reporting it
+    # anyway would tell the OTA server this robot runs software that is not on
+    # its disk, so an unresolvable link counts as nothing installed.
+    if not (versions_dir(release) / name).is_dir():
+        return None
+    return name
+
+
+def _newest_available(release) -> Optional[str]:
+    generations = _generations(release)
+    return generations[-1][2].name if generations else None
+
+
+def ensure_tree(release) -> Optional[str]:
+    """Repair the live symlink after manual surgery. Returns what it did, or None.
+
+    `release/install` is one `rm` away from being wrong, and the package data
+    usually survives whatever happened to the link — so recover from the
+    versions on disk rather than treating the robot as empty and silently
+    reinstalling from scratch.
+    """
+    link = current_link(release)
+
+    if link.is_symlink():
+        if _current_dir_name(release) is not None:
+            return None  # healthy
+        recovered = _newest_available(release)
+        if recovered:
+            _point_current_at(release, recovered)
+            return f"relinked release/install to {recovered} (was dangling)"
+        try:
+            link.unlink()
+        except OSError:
+            pass
+        return "removed a dangling release/install link"
+
+    if link.is_dir():
+        # Either a pre-versioning tree or a directory someone restored on top.
+        if migrate_legacy_tree(release):
+            return "adopted release/install directory as a version"
+        return None
+
+    recovered = _newest_available(release)
+    if recovered:
+        _point_current_at(release, recovered)
+        return f"restored missing release/install link to {recovered}"
+    return None
+
+
+def current_version(release) -> Optional[str]:
+    """Version the live symlink points at, or None if nothing is committed."""
+    name = _current_dir_name(release)
+    if not name:
+        return None
+    parsed = _split_generation(name)
+    return parsed[1] if parsed else name
+
+
+def previous_version(release) -> Optional[str]:
+    """Version a rollback would restore."""
+    name = _previous_dir_name(release)
+    if not name:
+        return None
+    parsed = _split_generation(name)
+    return parsed[1] if parsed else name
+
+
+def _previous_dir_name(release) -> Optional[str]:
+    try:
+        name = _previous_file(release).read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not name or not (versions_dir(release) / name).is_dir():
+        return None
+    return name
+
+
+def _write_previous(release, dir_name: Optional[str]) -> None:
+    path = _previous_file(release)
+    try:
+        if dir_name is None:
+            if path.exists():
+                path.unlink()
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(dir_name, encoding="utf-8")
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Commit point
+# ---------------------------------------------------------------------------
+
+
+def _point_current_at(release, dir_name: str) -> None:
+    """Repoint the live symlink. This is the only step that changes what runs."""
+    link = current_link(release)
+    tmp = link.with_name(link.name + ".tmp")
+    try:
+        if tmp.is_symlink() or tmp.exists():
+            tmp.unlink()
+    except OSError:
+        pass
+
+    # Relative so the tree survives being moved or mounted elsewhere.
+    os.symlink(os.path.join(_VERSIONS_DIR, dir_name), tmp, target_is_directory=True)
+    os.replace(tmp, link)
+
+
+def migrate_legacy_tree(release) -> bool:
+    """Convert a pre-versioning `release/install` directory into generation 1.
+
+    Moves rather than copies: an install tree is large, and a copy would need
+    twice the disk on exactly the robots least likely to have it.
+    """
+    link = current_link(release)
+    if link.is_symlink():
+        return False
+    if not link.is_dir():
+        return False
+
+    target = (
+        versions_dir(release) / f"{_next_generation(release):04d}-{_LEGACY_VERSION}"
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    link.rename(target)
+    _point_current_at(release, target.name)
+    return True
+
+
+def _clone_tree(src: Path, dst: Path) -> None:
+    """Hardlink-clone so a partial install keeps untouched packages for free."""
+    shutil.copytree(src, dst, copy_function=os.link, symlinks=True)
+
+
+def stage_version(release, version: str) -> Path:
+    """Prepare a new tree seeded from the live one. Nothing here is live yet."""
+    staging = versions_dir(release) / f"{_next_generation(release):04d}-{version}"
+    staging.parent.mkdir(parents=True, exist_ok=True)
+
+    current = _current_dir_name(release)
+    current_dir = versions_dir(release) / current if current else None
+    if current_dir and current_dir.is_dir():
+        _clone_tree(current_dir, staging)
+    else:
+        staging.mkdir(parents=True, exist_ok=True)
+    return staging
+
+
+def replace_package_dir(staging: Path, relative: Path) -> Path:
+    """Clear a package directory inside a staged tree before writing into it.
+
+    A staged tree is hardlink-cloned from the live one, so its files share
+    inodes with the version a rollback would restore. Writing into an existing
+    file would edit that version too. Removing the directory first breaks the
+    link; the OTA extract path already does exactly this, and anything else
+    writing into a staged tree must too.
+    """
+    target = staging / relative
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _resolve_version_dir(release, version: str) -> Optional[Path]:
+    matches = [entry for gen, name, entry in _generations(release) if name == version]
+    return matches[-1] if matches else None
+
+
+def commit_version(release, version: str) -> Optional[str]:
+    """Make a staged version live. Returns the directory now current."""
+    target = _resolve_version_dir(release, version)
+    if target is None:
+        return None
+
+    outgoing = _current_dir_name(release)
+    _point_current_at(release, target.name)
+    if outgoing and outgoing != target.name:
+        _write_previous(release, outgoing)
+    return target.name
+
+
+def rollback(release) -> Optional[str]:
+    """Restore the previous version. Returns its version, or None if there is none."""
+    previous = _previous_dir_name(release)
+    if not previous:
+        return None
+
+    _point_current_at(release, previous)
+
+    # The version before the restored one becomes the next rollback target, so
+    # a second failure does not bounce back onto the version just rejected.
+    ordered = [name for _, _, entry in _generations(release) for name in (entry.name,)]
+    try:
+        index = ordered.index(previous)
+    except ValueError:
+        index = 0
+    _write_previous(release, ordered[index - 1] if index > 0 else None)
+
+    parsed = _split_generation(previous)
+    return parsed[1] if parsed else previous
+
+
+def discard_staging(release, version: str) -> None:
+    """Remove an uncommitted staged tree."""
+    target = _resolve_version_dir(release, version)
+    if target is None or target.name == _current_dir_name(release):
+        return
+    shutil.rmtree(target, ignore_errors=True)
+
+
+def prune_versions(release, keep: int = 2) -> List[str]:
+    """Drop old generations, never the live one or its rollback target."""
+    generations = _generations(release)
+    protected = {_current_dir_name(release), _previous_dir_name(release)}
+    keep = max(1, keep)
+
+    removed = []
+    for _, _, entry in generations[:-keep] if keep < len(generations) else []:
+        if entry.name in protected:
+            continue
+        shutil.rmtree(entry, ignore_errors=True)
+        removed.append(entry.name)
+    return removed

--- a/commands/install_tree.py
+++ b/commands/install_tree.py
@@ -14,11 +14,25 @@ already live still stages into a fresh directory instead of mutating the tree
 underneath a running system.
 """
 
+import errno
 import os
 import re
 import shutil
 from pathlib import Path
 from typing import List, Optional, Tuple
+
+
+class InstallTreeUnusable(Exception):
+    """The versioned tree cannot be prepared where it has been placed.
+
+    Almost always a layout question rather than a transient fault: mounting a
+    bigger partition at `release/install` puts it on a different filesystem
+    from `release/versions`, and neither the rename that adopts an existing
+    tree nor the hardlink clone that stages a new one crosses that boundary.
+    Raised with the cause named so the operator can move the mount instead of
+    reading a traceback.
+    """
+
 
 _VERSIONS_DIR = "versions"
 _CURRENT_LINK = "install"
@@ -92,6 +106,24 @@ def _current_dir_name(release) -> Optional[str]:
     return name
 
 
+def _is_our_link(link: Path) -> bool:
+    """Whether this symlink is one this module created.
+
+    Ours are always relative and inside `versions/`. Pointing
+    `release/install` at another disk is how an operator moves a large package
+    tree off a small root filesystem, and that link is not ours to repair —
+    "repairing" it would put the next install back on the disk they moved it
+    off, while reporting that something was fixed.
+    """
+    try:
+        target = os.readlink(link)
+    except OSError:
+        return False
+    if os.path.isabs(target):
+        return False
+    return Path(target).parts[:1] == (_VERSIONS_DIR,)
+
+
 def _newest_available(release) -> Optional[str]:
     generations = _generations(release)
     return generations[-1][2].name if generations else None
@@ -108,6 +140,8 @@ def ensure_tree(release) -> Optional[str]:
     link = current_link(release)
 
     if link.is_symlink():
+        if not _is_our_link(link):
+            return None  # someone else's link; leave it exactly as it is
         if _current_dir_name(release) is not None:
             return None  # healthy
         recovered = _newest_available(release)
@@ -231,9 +265,24 @@ def migrate_legacy_tree(release) -> bool:
         versions_dir(release) / f"{_next_generation(release):04d}-{_LEGACY_VERSION}"
     )
     target.parent.mkdir(parents=True, exist_ok=True)
-    link.rename(target)
+    try:
+        link.rename(target)
+    except OSError as exc:
+        raise InstallTreeUnusable(_layout_hint(link, target.parent, exc)) from exc
     _point_current_at(release, target.name)
     return True
+
+
+def _layout_hint(source, destination, exc: BaseException) -> str:
+    """Explain a filesystem refusal in terms of what an operator can change."""
+    if getattr(exc, "errno", None) == errno.EXDEV:
+        return (
+            f"{source} and {destination} are on different filesystems. The "
+            "versioned install tree moves and hardlinks between them, which "
+            "the kernel will not do across a mount point — mount the whole "
+            "release/ directory rather than release/install."
+        )
+    return f"could not prepare the install tree at {destination}: {exc}"
 
 
 def _clone_tree(src: Path, dst: Path) -> None:
@@ -249,7 +298,13 @@ def stage_version(release, version: str) -> Path:
     current = _current_dir_name(release)
     current_dir = versions_dir(release) / current if current else None
     if current_dir and current_dir.is_dir():
-        _clone_tree(current_dir, staging)
+        try:
+            _clone_tree(current_dir, staging)
+        except (OSError, shutil.Error) as exc:
+            shutil.rmtree(staging, ignore_errors=True)
+            raise InstallTreeUnusable(
+                _layout_hint(current_dir, staging.parent, exc)
+            ) from exc
     else:
         staging.mkdir(parents=True, exist_ok=True)
 

--- a/commands/install_tree.py
+++ b/commands/install_tree.py
@@ -24,6 +24,7 @@ _VERSIONS_DIR = "versions"
 _CURRENT_LINK = "install"
 _PREVIOUS_FILE = ".previous-version"
 _SESSION_FILE = ".current-session"
+_STAGING_MARKER = ".staging"
 _LEGACY_VERSION = "legacy"
 
 _GENERATION_RE = re.compile(r"^(\d{4})-(.+)$")
@@ -251,7 +252,18 @@ def stage_version(release, version: str) -> Path:
         _clone_tree(current_dir, staging)
     else:
         staging.mkdir(parents=True, exist_ok=True)
+
+    # Marked until committed, so a tree left behind by a crash is recognisable
+    # as abandoned rather than counted as a version worth retaining.
+    try:
+        (staging / _STAGING_MARKER).write_text("", encoding="utf-8")
+    except OSError:
+        pass
     return staging
+
+
+def _is_staging(version_dir: Path) -> bool:
+    return (version_dir / _STAGING_MARKER).exists()
 
 
 def replace_package_dir(staging: Path, relative: Path) -> Path:
@@ -290,6 +302,11 @@ def commit_version(
     target = _resolve_version_dir(release, version)
     if target is None:
         return None
+
+    try:
+        (target / _STAGING_MARKER).unlink()
+    except OSError:
+        pass
 
     outgoing = _current_dir_name(release)
     committed_by = _read_commit_session(release)
@@ -332,13 +349,27 @@ def discard_staging(release, version: str) -> None:
 
 
 def prune_versions(release, keep: int = 2) -> List[str]:
-    """Drop old generations, never the live one or its rollback target."""
+    """Drop old generations, never the live one or its rollback target.
+
+    Abandoned staging trees are removed outright rather than counted toward
+    `keep`: nothing points at them, and being the newest generations they would
+    otherwise take the slots real versions should hold — so `keep=2` would stop
+    meaning two versions.
+    """
     generations = _generations(release)
     protected = {_current_dir_name(release), _previous_dir_name(release)}
     keep = max(1, keep)
 
     removed = []
-    for _, _, entry in generations[:-keep] if keep < len(generations) else []:
+    committed = []
+    for _, _, entry in generations:
+        if _is_staging(entry) and entry.name not in protected:
+            shutil.rmtree(entry, ignore_errors=True)
+            removed.append(entry.name)
+        else:
+            committed.append(entry)
+
+    for entry in committed[:-keep] if keep < len(committed) else []:
         if entry.name in protected:
             continue
         shutil.rmtree(entry, ignore_errors=True)

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -56,7 +56,6 @@ _install_session_id = None
 _pending_snapshot_reports = {}
 
 # Caches file-backed robot API keys by path and file stat metadata.
-_robot_api_key_cache = {}
 
 # Default archive name prefix (build_type is appended for debug)
 DEFAULT_ARCHIVE_NAME = "raisin-robot"
@@ -98,10 +97,8 @@ _ROBOT_API_KEY_FILE_ENV = "RAISIN_ROBOT_API_KEY_FILE"  # pragma: allowlist secre
 _ROBOT_NODE_ENV = "RAISIN_ROBOT_NODE"
 _ROBOT_NODE_KEY_ENV = "RAISIN_ROBOT_NODE_KEY"
 _ROBOT_CONFIG_FILES = ("configuration_setting.yaml", "secrets.yaml")
-_robot_auth_warning_keys = set()
 
 # Caches parsed local config by path and file stat metadata.
-_local_config_cache = {}
 
 # Client identity attached to robot OTA audit/history records.
 DEFAULT_CLIENT_VERSION = "raisin-cli"
@@ -110,6 +107,32 @@ DEFAULT_CLIENT_VERSION = "raisin-cli"
 # ============================================================================
 # Runtime context
 # ============================================================================
+
+
+def _normalize_optional_string(value) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    if not value or value.lower() in {"none", "null"}:
+        return None
+    return value
+
+
+@dataclass(frozen=True)
+class RobotIdentity:
+    """Who this process is to the OTA server.
+
+    Resolving this — environment, config files, a key file under someone's
+    HOME — is the caller's job. A robot on a service account and a developer
+    at a shell answer it differently, and a human running the tool on a robot
+    must not be attributed to the robot just because a key file is on disk.
+    """
+
+    api_key: str
+    node_key: str
+    client_version: str = DEFAULT_CLIENT_VERSION
 
 
 @dataclass(frozen=True)
@@ -125,6 +148,7 @@ class OtaContext:
     os_type: str
     os_version: str
     architecture: str
+    robot: Optional[RobotIdentity] = None
 
     @property
     def platform(self) -> str:
@@ -150,6 +174,11 @@ def configure(context: OtaContext) -> None:
     """Point the core at a workspace and platform. Call once at startup."""
     global _context
     _context = context
+
+
+def _client_version() -> str:
+    robot = _ctx().robot
+    return robot.client_version if robot else DEFAULT_CLIENT_VERSION
 
 
 def _ctx() -> OtaContext:
@@ -228,258 +257,6 @@ def get_ssh_key_path() -> Path:
 
     # 3. Default fallback
     return ssh_dir / "id_ed25519"
-
-
-def _normalize_optional_string(value) -> Optional[str]:
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        value = str(value)
-    value = value.strip()
-    if not value or value.lower() in {"none", "null"}:
-        return None
-    return value
-
-
-def _load_local_config() -> dict:
-    """Best-effort read of local configuration without enforcing full config validity.
-
-    Cached on file stat metadata: robot auth headers are rebuilt for every
-    package download, and each rebuild resolves both the API key and the node
-    key, so an uncached read re-parses the YAML twice per package.
-    """
-    script_dir_path = _ctx().workspace
-    for filename in _ROBOT_CONFIG_FILES:
-        config_path = script_dir_path / filename
-        try:
-            stat_result = config_path.stat()
-        except OSError:
-            continue
-        if not stat.S_ISREG(stat_result.st_mode):
-            continue
-
-        cache_token = (stat_result.st_mtime_ns, stat_result.st_size)
-        cached = _local_config_cache.get(config_path)
-        if cached and cached[0] == cache_token:
-            return cached[1]
-
-        try:
-            config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-        except (OSError, yaml.YAMLError):
-            return {}
-        config = config if isinstance(config, dict) else {}
-        _local_config_cache[config_path] = (cache_token, config)
-        return config
-    return {}
-
-
-def _get_nested_config_value(config: dict, path: tuple) -> Optional[str]:
-    current = config
-    for key in path:
-        if not isinstance(current, dict):
-            return None
-        current = current.get(key)
-    return _normalize_optional_string(current)
-
-
-def _get_local_config_value(paths: tuple) -> Optional[str]:
-    config = _load_local_config()
-    for path in paths:
-        value = _get_nested_config_value(config, path)
-        if value:
-            return value
-    return None
-
-
-def get_robot_api_key_path() -> Path:
-    """Get the local robot API key path.
-
-    Resolution order:
-        1. RAISIN_ROBOT_API_KEY_FILE environment variable
-        2. ~/.config/raisin/robot-api-key
-    """
-    env_path = os.environ.get(_ROBOT_API_KEY_FILE_ENV, "").strip()
-    if env_path:
-        return Path(env_path).expanduser()
-    return Path.home() / ".config" / "raisin" / _ROBOT_API_KEY_FILE
-
-
-def save_robot_api_key(api_key: str, path: Optional[Path] = None) -> Path:
-    """Persist a robot API key with owner-only file permissions."""
-    key = (api_key or "").strip()
-    if not key:
-        raise ValueError("Robot API key cannot be empty")
-
-    target = Path(path).expanduser() if path else get_robot_api_key_path()
-    target.parent.mkdir(parents=True, exist_ok=True)
-
-    temp_path = target.with_name(f".{target.name}.tmp")
-    try:
-        fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(key + "\n")
-        temp_path.replace(target)
-    finally:
-        try:
-            if temp_path.exists():
-                temp_path.unlink()
-        except OSError:
-            pass
-
-    try:
-        os.chmod(target, 0o600)
-    except OSError:
-        pass
-    _cache_robot_api_key(target, key)
-    return target
-
-
-def _api_key_cache_token(stat_result) -> tuple:
-    return (
-        stat_result.st_mtime_ns,
-        stat_result.st_size,
-        stat_result.st_mode & 0o777,
-    )
-
-
-def _cache_robot_api_key(key_path: Path, api_key: Optional[str]) -> None:
-    try:
-        stat_result = key_path.stat()
-    except OSError:
-        _robot_api_key_cache.pop(key_path, None)
-        return
-    _robot_api_key_cache[key_path] = (
-        _api_key_cache_token(stat_result),
-        api_key,
-        False,
-    )
-
-
-def _read_robot_api_key_file_detailed(key_path: Path) -> tuple:
-    """Read a key file, reporting whether a failure was already explained.
-
-    Returns (key, explained). `explained` is True when the reason the key is
-    unusable has already been printed — either by this call or by the earlier
-    call that cached the result — so callers do not stack a second, vaguer
-    warning on top of a specific one.
-    """
-    try:
-        stat_result = key_path.stat()
-    except FileNotFoundError:
-        _robot_api_key_cache.pop(key_path, None)
-        return (None, False)
-    except OSError as e:
-        print(f"⚠️ Failed to read robot API key file '{key_path}': {e}")
-        return (None, True)
-
-    cache_token = _api_key_cache_token(stat_result)
-    cached = _robot_api_key_cache.get(key_path)
-    if cached and cached[0] == cache_token:
-        return (cached[1], cached[2])
-
-    if os.name == "posix" and (stat_result.st_mode & 0o077):
-        print(
-            "⚠️ Ignoring robot API key file with insecure permissions: "
-            f"{key_path} (run: chmod 600 {key_path})"
-        )
-        _robot_api_key_cache[key_path] = (cache_token, None, True)
-        return (None, True)
-
-    try:
-        key = key_path.read_text(encoding="utf-8").strip()
-    except OSError as e:
-        print(f"⚠️ Failed to read robot API key file '{key_path}': {e}")
-        return (None, True)
-
-    cached_key = key or None
-    _robot_api_key_cache[key_path] = (cache_token, cached_key, False)
-    return (cached_key, False)
-
-
-def _read_robot_api_key_file(key_path: Path) -> Optional[str]:
-    return _read_robot_api_key_file_detailed(key_path)[0]
-
-
-def get_robot_api_key() -> Optional[str]:
-    """Read the robot API key from env or the local key file.
-
-    Resolution order:
-        1. RAISIN_ROBOT_API_KEY
-        2. RAISIN_ROBOT_API_KEY_FILE
-        3. configuration_setting.yaml/secrets.yaml robot.api_key
-        4. ~/.config/raisin/robot-api-key
-
-    File-backed keys are ignored on POSIX systems if group/other permissions
-    are enabled.
-    """
-    env_key = os.environ.get(_ROBOT_API_KEY_ENV, "").strip()
-    if env_key:
-        return env_key
-
-    env_key_file = os.environ.get(_ROBOT_API_KEY_FILE_ENV, "").strip()
-    if env_key_file:
-        # An explicitly pinned path is a deliberate choice. Do not fall through
-        # to the config file or the default path when it does not resolve —
-        # say so instead, or the robot quietly downloads as an anonymous client.
-        key, explained = _read_robot_api_key_file_detailed(
-            Path(env_key_file).expanduser()
-        )
-        if not key and not explained:
-            _warn_robot_auth_config_once(
-                f"unreadable_key_file:{env_key_file}",
-                f"⚠️ {_ROBOT_API_KEY_FILE_ENV} points at '{env_key_file}' but no "
-                "robot API key could be read from it. Using legacy OTA "
-                "authentication instead.",
-            )
-        return key
-
-    config_key = _get_local_config_value(
-        (
-            ("robot", "api_key"),
-            ("robot", "apiKey"),
-            ("ota", "robot_api_key"),
-            ("robot_api_key",),
-        )
-    )
-    if config_key:
-        return config_key
-
-    return _read_robot_api_key_file(get_robot_api_key_path())
-
-
-def get_robot_node_key() -> Optional[str]:
-    """Read the robot-local node key required by robot-authenticated endpoints."""
-    for env_name in (_ROBOT_NODE_ENV, _ROBOT_NODE_KEY_ENV):
-        env_value = _normalize_optional_string(os.environ.get(env_name))
-        if env_value:
-            return env_value
-
-    return _get_local_config_value(
-        (
-            ("robot", "node"),
-            ("robot", "node_key"),
-            ("robot", "nodeKey"),
-            ("ota", "robot_node"),
-            ("robot_node",),
-            ("robot_node_key",),
-        )
-    )
-
-
-def _warn_robot_auth_config_once(key: str, message: str) -> None:
-    if key in _robot_auth_warning_keys:
-        return
-    _robot_auth_warning_keys.add(key)
-    print(message)
-
-
-def get_client_version() -> str:
-    """Return the OTA client identity used in robot audit/history records."""
-    for env_name in ("RAISIN_OTA_CLIENT_VERSION", "RAISIN_CLIENT_VERSION"):
-        value = os.environ.get(env_name, "").strip()
-        if value:
-            return value
-    return DEFAULT_CLIENT_VERSION
 
 
 def _install_session_path() -> Path:
@@ -653,7 +430,7 @@ def robot_reporting_enabled() -> bool:
     credential. Buffering install events there would grow a file that can never
     be flushed, so nothing is recorded in the first place.
     """
-    return bool(get_robot_api_key() and get_robot_node_key())
+    return _ctx().robot is not None
 
 
 def note_install_failure(
@@ -747,7 +524,7 @@ def record_install_event(
         "installSessionId": session_id,
         "eventType": event_type,
         "occurredAt": _utc_now_iso(),
-        "clientVersion": get_client_version(),
+        "clientVersion": _client_version(),
     }
     for key, value in (
         ("stage", stage),
@@ -1564,25 +1341,16 @@ def _stream_download(url: str, download_path: Path, error_context: str = "") -> 
 
 def _robot_auth_headers(install_session_id: Optional[str] = None) -> Optional[dict]:
     """Build robot-authenticated headers, or return None when unconfigured."""
-    api_key = get_robot_api_key()
-    if not api_key:
-        return None
-    node_key = get_robot_node_key()
-    if not node_key:
-        _warn_robot_auth_config_once(
-            "missing_robot_node",
-            "⚠️ Robot API key is configured but robot node is missing "
-            "(set RAISIN_ROBOT_NODE or configuration_setting.yaml robot.node). "
-            "Using legacy OTA authentication instead.",
-        )
+    robot = _ctx().robot
+    if robot is None:
         return None
 
     session_id = install_session_id or get_install_session_id()
     return {
-        "Authorization": f"Robot {api_key}",
-        "X-Client-Version": get_client_version(),
+        "Authorization": f"Robot {robot.api_key}",
+        "X-Client-Version": robot.client_version,
         "X-Install-Session-Id": session_id,
-        "X-Robot-Node": node_key,
+        "X-Robot-Node": robot.node_key,
     }
 
 
@@ -2276,7 +2044,7 @@ def report_software_snapshot(
         "archiveId": archive_id,
         "archivePackages": packages,
         "installSessionId": session_id,
-        "clientVersion": get_client_version(),
+        "clientVersion": _client_version(),
     }
     if archive_name:
         payload["name"] = archive_name

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -1990,13 +1990,33 @@ def _extract_and_read_deps(
     print(f"✅ Successfully installed '{package_name}=={version}' from OTA server.")
     _write_install_metadata(install_dir, install_metadata)
 
-    # Read dependencies from release.yaml
+    # Read dependencies from release.yaml. The file ships inside the package,
+    # so it is not necessarily well formed: `safe_load` happily returns a str
+    # or a list, and `or {}` does not catch either — the install then died on
+    # AttributeError instead of installing.
     dependencies = []
     release_yaml = install_dir / "release.yaml"
     if release_yaml.is_file():
-        with open(release_yaml, "r") as f:
-            release_info = yaml.safe_load(f) or {}
-            dependencies = release_info.get("dependencies", [])
+        try:
+            with open(release_yaml, "r") as f:
+                release_info = yaml.safe_load(f)
+        except (OSError, yaml.YAMLError) as e:
+            print(f"⚠️ Could not read release.yaml for '{package_name}': {e}")
+            release_info = None
+
+        if isinstance(release_info, dict):
+            declared = release_info.get("dependencies", [])
+            if isinstance(declared, list):
+                dependencies = declared
+            elif declared:
+                print(
+                    f"⚠️ Ignoring malformed 'dependencies' in release.yaml for "
+                    f"'{package_name}': expected a list."
+                )
+        elif release_info is not None:
+            print(
+                f"⚠️ Ignoring release.yaml for '{package_name}': expected a " "mapping."
+            )
 
     result = {"version": version, "dependencies": dependencies}
     if install_metadata:
@@ -2625,7 +2645,7 @@ def download_all_from_archive(
         )
         return {}
 
-    install_tree.commit_version(release, actual_version)
+    install_tree.commit_version(release, actual_version, session=install_session_id)
     print(f"🔀 Switched release/install to {archive_name} v{actual_version}.")
 
     broken = _unusable_packages(install_base_path, requested, build_type)

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -20,6 +20,7 @@ import struct
 import subprocess
 import tempfile
 import time
+import uuid
 import zipfile
 
 import requests
@@ -42,6 +43,10 @@ _auth_failed = False
 # Key: (archive_name, platform_str) → Value: (packages_list, archive_id, archive_version)
 _archive_cache = {}
 
+# Correlates all OTA package downloads and the final software snapshot from
+# one CLI process.
+_install_session_id = None
+
 # Default archive name prefix (build_type is appended for debug)
 DEFAULT_ARCHIVE_NAME = "raisin-robot"
 
@@ -53,6 +58,14 @@ _TOKEN_CACHE_FILE = ".ota_token_cache.json"
 
 # Per-install metadata file written after OTA extraction
 _INSTALL_METADATA_FILE = "ota-install.json"
+
+# Robot API key configuration. The key file is intentionally outside the repo.
+_ROBOT_API_KEY_FILE = "robot-api-key"  # pragma: allowlist secret
+_ROBOT_API_KEY_ENV = "RAISIN_ROBOT_API_KEY"  # pragma: allowlist secret
+_ROBOT_API_KEY_FILE_ENV = "RAISIN_ROBOT_API_KEY_FILE"  # pragma: allowlist secret
+
+# Client identity attached to robot OTA audit/history records.
+DEFAULT_CLIENT_VERSION = "raisin-cli"
 
 
 # ============================================================================
@@ -90,6 +103,90 @@ def get_ssh_key_path() -> Path:
 
     # 3. Default fallback
     return ssh_dir / "id_ed25519"
+
+
+def get_robot_api_key_path() -> Path:
+    """Get the local robot API key path.
+
+    Resolution order:
+        1. RAISIN_ROBOT_API_KEY_FILE environment variable
+        2. ~/.config/raisin/robot-api-key
+    """
+    env_path = os.environ.get(_ROBOT_API_KEY_FILE_ENV, "").strip()
+    if env_path:
+        return Path(env_path).expanduser()
+    return Path.home() / ".config" / "raisin" / _ROBOT_API_KEY_FILE
+
+
+def save_robot_api_key(api_key: str, path: Optional[Path] = None) -> Path:
+    """Persist a robot API key with owner-only file permissions."""
+    key = (api_key or "").strip()
+    if not key:
+        raise ValueError("Robot API key cannot be empty")
+
+    target = Path(path).expanduser() if path else get_robot_api_key_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(target.parent, 0o700)
+    except OSError:
+        pass
+
+    temp_path = target.with_name(f".{target.name}.tmp")
+    temp_path.write_text(key + "\n", encoding="utf-8")
+    try:
+        os.chmod(temp_path, 0o600)
+    except OSError:
+        pass
+    temp_path.replace(target)
+    try:
+        os.chmod(target, 0o600)
+    except OSError:
+        pass
+    return target
+
+
+def get_robot_api_key() -> Optional[str]:
+    """Read the robot API key from env or the local key file.
+
+    Env var is useful for CI/tests. The file path is ignored on POSIX systems
+    if group/other permissions are enabled.
+    """
+    env_key = os.environ.get(_ROBOT_API_KEY_ENV, "").strip()
+    if env_key:
+        return env_key
+
+    key_path = get_robot_api_key_path()
+    try:
+        if not key_path.is_file():
+            return None
+        if os.name == "posix" and (key_path.stat().st_mode & 0o077):
+            print(
+                "⚠️ Ignoring robot API key file with insecure permissions: "
+                f"{key_path} (run: chmod 600 {key_path})"
+            )
+            return None
+        key = key_path.read_text(encoding="utf-8").strip()
+        return key or None
+    except OSError as e:
+        print(f"⚠️ Failed to read robot API key file '{key_path}': {e}")
+        return None
+
+
+def get_client_version() -> str:
+    """Return the OTA client identity used in robot audit/history records."""
+    for env_name in ("RAISIN_OTA_CLIENT_VERSION", "RAISIN_CLIENT_VERSION"):
+        value = os.environ.get(env_name, "").strip()
+        if value:
+            return value
+    return DEFAULT_CLIENT_VERSION
+
+
+def get_install_session_id() -> str:
+    """Return a stable install session id for this CLI process."""
+    global _install_session_id
+    if not _install_session_id:
+        _install_session_id = str(uuid.uuid4())
+    return _install_session_id
 
 
 def get_archive_name(build_type: str, archive_name: Optional[str] = None) -> str:
@@ -811,13 +908,81 @@ def _stream_download(url: str, download_path: Path, error_context: str = "") -> 
         return False
 
 
+def _robot_auth_headers(install_session_id: Optional[str] = None) -> Optional[dict]:
+    """Build robot-authenticated headers, or return None when unconfigured."""
+    api_key = get_robot_api_key()
+    if not api_key:
+        return None
+
+    session_id = install_session_id or get_install_session_id()
+    return {
+        "Authorization": f"Robot {api_key}",
+        "X-Client-Version": get_client_version(),
+        "X-Install-Session-Id": session_id,
+    }
+
+
+def _stream_robot_package_download(
+    package_id: str,
+    package_name: str,
+    archive_name: str,
+    archive_version: str,
+    platform_str: str,
+    download_path: Path,
+    headers: dict,
+) -> bool:
+    """Download a package through the robot-authenticated by-key endpoint."""
+    base = get_ota_endpoint().rstrip("/")
+    url = f"{base}/robots/me/archives/by-key/packages/{package_id}/download"
+    params = {
+        "name": archive_name,
+        "platform": platform_str,
+        "version": archive_version.lstrip("vV"),
+    }
+
+    try:
+        download_path.parent.mkdir(parents=True, exist_ok=True)
+        with requests.get(
+            url, headers=headers, params=params, stream=True, timeout=60
+        ) as resp:
+            resp.raise_for_status()
+            with open(download_path, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    f.write(chunk)
+        return True
+    except requests.RequestException as e:
+        if download_path.exists():
+            try:
+                download_path.unlink()
+            except OSError:
+                pass
+        print(f"⚠️ Robot OTA download failed for '{package_name}': {e}")
+        return False
+
+
 def _download_package_blob(
     archive_id: str,
     package_id: str,
     package_name: str,
     download_path: Path,
+    archive_name: Optional[str] = None,
+    archive_version: Optional[str] = None,
+    platform_str: Optional[str] = None,
+    install_session_id: Optional[str] = None,
 ) -> bool:
     """Download a single package blob from an archive."""
+    robot_headers = _robot_auth_headers(install_session_id)
+    if robot_headers and archive_name and archive_version and platform_str:
+        return _stream_robot_package_download(
+            package_id=package_id,
+            package_name=package_name,
+            archive_name=archive_name,
+            archive_version=archive_version,
+            platform_str=platform_str,
+            download_path=download_path,
+            headers=robot_headers,
+        )
+
     base = get_ota_endpoint().rstrip("/")
     url = f"{base}/archives/{archive_id}/packages/{package_id}/download"
     return _stream_download(url, download_path, package_name)
@@ -880,7 +1045,10 @@ def _extract_and_read_deps(
             release_info = yaml.safe_load(f) or {}
             dependencies = release_info.get("dependencies", [])
 
-    return {"version": version, "dependencies": dependencies}
+    result = {"version": version, "dependencies": dependencies}
+    if install_metadata:
+        result["otaMetadata"] = install_metadata
+    return result
 
 
 def _build_archive_install_metadata(
@@ -896,6 +1064,7 @@ def _build_archive_install_metadata(
     requested_archive_version: Optional[str],
     manifest_hash: Optional[str],
     blob_hash: Optional[str],
+    install_session_id: Optional[str] = None,
 ) -> dict:
     """Build install metadata for archive-based OTA downloads."""
     return {
@@ -909,6 +1078,7 @@ def _build_archive_install_metadata(
         "archiveId": archive_id,
         "archiveVersion": actual_version,
         "requestedArchiveVersion": requested_archive_version,
+        "installSessionId": install_session_id,
         "packageName": package_name,
         "packageId": package_id,
         "packageVersion": version,
@@ -916,6 +1086,135 @@ def _build_archive_install_metadata(
         "manifestHash": manifest_hash,
         "blobHash": blob_hash,
     }
+
+
+def _snapshot_package_from_metadata(metadata: dict) -> Optional[dict]:
+    """Convert one ota-install.json document into a snapshot package item."""
+    package_id = str(metadata.get("packageId") or "").strip()
+    package_name = str(metadata.get("packageName") or "").strip()
+    version = str(metadata.get("packageVersion") or "").strip().lstrip("vV")
+    if not package_id or not package_name or not version:
+        return None
+    return {
+        "packageId": package_id,
+        "packageName": package_name,
+        "version": version,
+    }
+
+
+def _collect_archive_snapshot_packages(
+    install_base_path: Path,
+    archive_id: str,
+    platform_str: str,
+    build_type: str,
+) -> list:
+    """Collect currently installed package metadata for an archive."""
+    metadata_pattern = (
+        f"*/{g.os_type}/{g.os_version}/{g.architecture}/{build_type}/"
+        f"{_INSTALL_METADATA_FILE}"
+    )
+    packages_by_id = {}
+    for metadata_path in sorted(install_base_path.glob(metadata_pattern)):
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        if metadata.get("source") != "archive":
+            continue
+        if metadata.get("archiveId") != archive_id:
+            continue
+        if metadata.get("platform") != platform_str:
+            continue
+        if metadata.get("buildType") != build_type:
+            continue
+
+        package = _snapshot_package_from_metadata(metadata)
+        if package:
+            packages_by_id[package["packageId"]] = package
+
+    return list(packages_by_id.values())
+
+
+def report_software_snapshot(
+    archive_id: str,
+    archive_name: Optional[str],
+    archive_version: Optional[str],
+    platform_str: str,
+    packages: list,
+    install_session_id: Optional[str] = None,
+) -> bool:
+    """Report the robot's installed software snapshot to the OTA server."""
+    if not packages:
+        return False
+
+    headers = _robot_auth_headers(install_session_id)
+    if not headers:
+        return False
+
+    session_id = install_session_id or get_install_session_id()
+    payload = {
+        "archiveId": archive_id,
+        "packages": packages,
+        "installSessionId": session_id,
+        "clientVersion": get_client_version(),
+    }
+    if archive_name:
+        payload["name"] = archive_name
+    if archive_version:
+        payload["version"] = archive_version.lstrip("vV")
+    if platform_str:
+        payload["platform"] = platform_str
+
+    request_headers = dict(headers)
+    request_headers["Content-Type"] = "application/json"
+    base = get_ota_endpoint().rstrip("/")
+    try:
+        resp = requests.post(
+            f"{base}/robots/me/software-snapshot",
+            headers=request_headers,
+            json=payload,
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return True
+    except requests.RequestException as e:
+        print(f"⚠️ Failed to report OTA software snapshot: {e}")
+        return False
+
+
+def _report_snapshot_from_install_metadata(
+    install_base_path: Path,
+    archive_id: str,
+    archive_name: str,
+    archive_version: Optional[str],
+    platform_str: str,
+    build_type: str,
+    install_session_id: str,
+) -> bool:
+    packages = _collect_archive_snapshot_packages(
+        install_base_path=install_base_path,
+        archive_id=archive_id,
+        platform_str=platform_str,
+        build_type=build_type,
+    )
+    if not packages:
+        return False
+
+    if report_software_snapshot(
+        archive_id=archive_id,
+        archive_name=archive_name,
+        archive_version=archive_version,
+        platform_str=platform_str,
+        packages=packages,
+        install_session_id=install_session_id,
+    ):
+        print(
+            "🛰️  Reported OTA software snapshot "
+            f"({len(packages)} packages, session {install_session_id})."
+        )
+        return True
+    return False
 
 
 def download_package(
@@ -1024,8 +1323,19 @@ def download_package(
         Path(g.script_directory) / "install" / f"{package_name}-ota-{version}.zip"
     )
 
+    install_session_id = get_install_session_id()
+
     print(f"⬇️  Downloading '{package_name}' v{version} from OTA server...")
-    if not _download_package_blob(archive_id, pkg_id, package_name, download_file):
+    if not _download_package_blob(
+        archive_id,
+        pkg_id,
+        package_name,
+        download_file,
+        archive_name=archive_name,
+        archive_version=actual_version,
+        platform_str=platform_str,
+        install_session_id=install_session_id,
+    ):
         return None
 
     install_metadata = _build_archive_install_metadata(
@@ -1041,15 +1351,27 @@ def download_package(
         requested_archive_version=archive_version,
         manifest_hash=best_pkg.get("manifestHash"),
         blob_hash=best_pkg.get("blobHash"),
+        install_session_id=install_session_id,
     )
 
-    return _extract_and_read_deps(
+    result = _extract_and_read_deps(
         download_file,
         install_dir,
         package_name,
         version,
         install_metadata=install_metadata,
     )
+    if result:
+        _report_snapshot_from_install_metadata(
+            install_base_path=install_base_path,
+            archive_id=archive_id,
+            archive_name=archive_name,
+            archive_version=actual_version,
+            platform_str=platform_str,
+            build_type=build_type,
+            install_session_id=install_session_id,
+        )
+    return result
 
 
 def download_all_from_archive(
@@ -1110,6 +1432,7 @@ def download_all_from_archive(
         return {}
 
     print(f"📦 Using archive: {archive_name} v{actual_version or 'latest'}")
+    install_session_id = get_install_session_id()
 
     results = {}
     for pkg in packages:
@@ -1140,7 +1463,16 @@ def download_all_from_archive(
         )
 
         print(f"⬇️  Downloading '{name}' v{version} from OTA server...")
-        if not _download_package_blob(archive_id, pkg_id, name, download_file):
+        if not _download_package_blob(
+            archive_id,
+            pkg_id,
+            name,
+            download_file,
+            archive_name=archive_name,
+            archive_version=actual_version,
+            platform_str=platform_str,
+            install_session_id=install_session_id,
+        ):
             continue
 
         install_metadata = _build_archive_install_metadata(
@@ -1156,6 +1488,7 @@ def download_all_from_archive(
             requested_archive_version=archive_version,
             manifest_hash=pkg.get("manifestHash"),
             blob_hash=pkg.get("blobHash"),
+            install_session_id=install_session_id,
         )
 
         result = _extract_and_read_deps(
@@ -1167,6 +1500,17 @@ def download_all_from_archive(
         )
         if result:
             results[name] = result
+
+    if results:
+        _report_snapshot_from_install_metadata(
+            install_base_path=install_base_path,
+            archive_id=archive_id,
+            archive_name=archive_name,
+            archive_version=actual_version,
+            platform_str=platform_str,
+            build_type=build_type,
+            install_session_id=install_session_id,
+        )
 
     return results
 

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -80,6 +80,10 @@ _INSTALL_SESSION_TTL_SECONDS = 24 * 60 * 60
 _INSTALL_EVENT_QUEUE_FILE = ".ota-install-events.jsonl"
 _INSTALL_EVENT_STATE_FILE = ".ota-install-events.state.json"
 _INSTALL_EVENT_BATCH_LIMIT = 100
+
+# An offline robot buffers indefinitely, so the queue needs a ceiling. Newest
+# events are kept: they describe the state the fleet still needs to know about.
+_MAX_BUFFERED_INSTALL_EVENTS = 1000
 _TERMINAL_EVENT_TYPES = frozenset({"succeeded", "failed", "rolled_back"})
 
 # First failure of the current attempt. A terminal event means the attempt
@@ -563,6 +567,16 @@ def _mark_install_event(session_id: str, marker: str) -> None:
         pass
 
 
+def robot_reporting_enabled() -> bool:
+    """Whether this machine has a robot identity to attribute reports to.
+
+    `raisin_master` also runs on developer workstations, which have no robot
+    credential. Buffering install events there would grow a file that can never
+    be flushed, so nothing is recorded in the first place.
+    """
+    return bool(get_robot_api_key() and get_robot_node_key())
+
+
 def note_install_failure(
     stage: str, error_code: Optional[str], message: Optional[str] = None
 ) -> None:
@@ -593,7 +607,7 @@ def install_attempt_started() -> bool:
     return _install_event_marker_seen(get_install_session_id(), "started")
 
 
-def report_install_outcome(overall_success: bool) -> Optional[dict]:
+def report_install_outcome(overall_success: bool) -> Optional[dict]:  # noqa: C901
     """Close the attempt with exactly one terminal event.
 
     Only the caller knows whether the run as a whole worked, and a noted
@@ -639,6 +653,9 @@ def record_install_event(
 
     Returns the event, or None when the guard suppressed it.
     """
+    if not robot_reporting_enabled():
+        return None
+
     session_id = install_session_id or get_install_session_id()
     marker = "terminal" if event_type in _TERMINAL_EVENT_TYPES else event_type
     if marker in ("started", "terminal") and _install_event_marker_seen(
@@ -716,6 +733,15 @@ def flush_install_events() -> bool:
             break
 
         remaining = [e for e in remaining if e.get("eventId") not in acked]
+
+    dropped = len(remaining) - _MAX_BUFFERED_INSTALL_EVENTS
+    if dropped > 0:
+        # Keep the newest: they describe where the robot actually ended up.
+        remaining = remaining[-_MAX_BUFFERED_INSTALL_EVENTS:]
+        print(
+            f"⚠️ OTA install-event buffer is full; discarded {dropped} of the "
+            "oldest event(s)."
+        )
 
     _write_install_event_queue(remaining)
     if remaining:

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -1028,17 +1028,19 @@ def upload_package(
                 resp.raise_for_status()
 
         # 4. Ensure package record exists
-        resp = requests.get(
-            f"{base}/packages",
-            headers=headers,
-            params={"name": package_name},
-            timeout=10,
-        )
-        resp.raise_for_status()
-        packages = _unwrap_response(resp.json())
+        found = _search_packages(base, headers, package_name)
+        if found is None:
+            # Creating the record now would risk a duplicate for a package that
+            # may well exist — the lookup never got an answer either way.
+            print(f"⚠️ OTA upload aborted: could not look up '{package_name}'")
+            return False
 
-        if packages and len(packages) > 0:
-            package_id = packages[0]["id"]
+        existing = next(
+            (p for p in found if p.get("name") == package_name),
+            None,
+        )
+        if existing:
+            package_id = existing["id"]
         else:
             resp = requests.post(
                 f"{base}/packages",
@@ -2578,33 +2580,138 @@ def download_all_from_archive(
     return results
 
 
-def _fetch_package_id_by_name(package_name: str) -> Optional[str]:
-    """Fetch package ID by name from the OTA server.
+# `GET /packages` caps `limit` at 100 and rejects anything larger outright.
+_PACKAGE_PAGE_SIZE = 100
 
-    Returns package UUID on success, None on failure.
+
+def _rejection_detail(response) -> str:
+    """The server's own words for why it refused the request."""
+    try:
+        body = response.json()
+    except ValueError:
+        return (getattr(response, "text", "") or "").strip()[:200]
+
+    error = body.get("error") if isinstance(body, dict) else None
+    if not isinstance(error, dict):
+        return str(body)[:200]
+
+    reasons = [
+        item["message"]
+        for item in error.get("validationErrors") or []
+        if isinstance(item, dict) and item.get("message")
+    ]
+    return "; ".join(reasons) or str(error.get("message", ""))[:200]
+
+
+def _get_packages_page(base, headers, params: dict, purpose: str) -> Optional[dict]:
+    """One page of ``GET /packages``, or None if the request did not succeed.
+
+    A refusal is announced rather than folded into an empty result. This
+    endpoint validates its query strictly — an unexpected parameter is a 400,
+    not an empty page — and reporting that as "no such package" sends whoever
+    is reading the output to look on the wrong side of the wire.
+    """
+    try:
+        resp = requests.get(
+            f"{base}/packages", headers=headers, params=params, timeout=10
+        )
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status_code", None)
+        if status is not None and 400 <= status < 500:
+            print(f"⚠️ OTA server rejected {purpose} ({status}):")
+            detail = _rejection_detail(response)
+            if detail:
+                print(f"   {detail}")
+        else:
+            print(f"⚠️ OTA server unreachable for {purpose}: {exc}")
+        return None
+
+    result = _unwrap_response(resp.json())
+    if isinstance(result, list):  # an older server that returned a bare array
+        return {"packages": result, "totalPages": 1}
+    if not isinstance(result, dict):
+        return {"packages": [], "totalPages": 1}
+
+    packages = result.get("packages")
+    return {
+        "packages": packages if isinstance(packages, list) else [],
+        "totalPages": result.get("totalPages") or 1,
+    }
+
+
+def _paginate_packages(
+    base, headers, search: Optional[str], page_size: int, purpose: str
+) -> Optional[list]:
+    """Every matching package, or None if any page was refused.
+
+    Returning what arrived before a refusal would present a truncated list as
+    the complete one, which is the same failure this is here to remove.
+    """
+    collected = []
+    page = 1
+    while True:
+        params = {"page": page, "limit": min(page_size, _PACKAGE_PAGE_SIZE)}
+        if search is not None:
+            params["search"] = search
+
+        result = _get_packages_page(base, headers, params, purpose)
+        if result is None:
+            return None
+
+        collected.extend(result["packages"])
+        if page >= result["totalPages"] or not result["packages"]:
+            return collected
+        page += 1
+
+
+def _search_packages(
+    base, headers, search: str, page_size: int = _PACKAGE_PAGE_SIZE
+) -> Optional[list]:
+    return _paginate_packages(
+        base, headers, search, page_size, f"the lookup for '{search}'"
+    )
+
+
+def _list_all_packages(page_size: int = _PACKAGE_PAGE_SIZE) -> Optional[list]:
+    """Every package on the server, or None if it could not be listed."""
+    ctx = _get_auth_context()
+    if not ctx:
+        return None
+    base, headers = ctx
+    return _paginate_packages(base, headers, None, page_size, "the package list")
+
+
+def _fetch_package_id_by_name(
+    package_name: str, page_size: int = _PACKAGE_PAGE_SIZE
+) -> Optional[str]:
+    """Package UUID for an exact name, or None if there is no such package.
+
+    ``GET /packages`` offers no exact-name lookup: ``search`` is a substring
+    match over name *and* description, so searching ``raisin`` also returns
+    ``raisin_gui``, ``raisin_plugin`` and anything merely mentioning it. Taking
+    the first hit would install a different package than the one asked for, so
+    the name has to match exactly.
     """
     ctx = _get_auth_context()
     if not ctx:
         return None
     base, headers = ctx
 
-    try:
-        resp = requests.get(
-            f"{base}/packages",
-            headers=headers,
-            params={"name": package_name},
-            timeout=10,
-        )
-        resp.raise_for_status()
-        result = _unwrap_response(resp.json())
-        packages = (
-            result.get("packages", result) if isinstance(result, dict) else result
-        )
-        if packages and len(packages) > 0:
-            return packages[0].get("id")
-        return None
-    except requests.RequestException:
-        return None
+    found = _search_packages(base, headers, package_name, page_size)
+    if found is None:
+        return None  # refused, and _get_packages_page has already said why
+
+    package_id = next(
+        (p.get("id") for p in found if p.get("name") == package_name),
+        None,
+    )
+    if package_id is None:
+        # Only claimed once the server actually answered. Saying "not found"
+        # for a request the server refused points at the wrong problem.
+        print(f"⚠️ Package '{package_name}' not found on OTA server.")
+    return package_id
 
 
 def _download_blob_by_hash(blob_hash: str, download_path: Path) -> bool:
@@ -2638,7 +2745,6 @@ def download_package_at_timestamp(
     # Get package ID first (this handles its own auth)
     package_id = _fetch_package_id_by_name(package_name)
     if not package_id:
-        print(f"⚠️ Package '{package_name}' not found on OTA server.")
         return None
 
     ctx = _get_auth_context()
@@ -2748,18 +2854,9 @@ def download_all_at_timestamp(
     base, headers = ctx
 
     try:
-        # Fetch all packages
-        resp = requests.get(
-            f"{base}/packages",
-            headers=headers,
-            params={"limit": 1000},
-            timeout=10,
-        )
-        resp.raise_for_status()
-        result = _unwrap_response(resp.json())
-        packages = (
-            result.get("packages", result) if isinstance(result, dict) else result
-        )
+        packages = _list_all_packages()
+        if packages is None:
+            return {}
 
         if not packages:
             print("⚠️ No packages found on OTA server.")

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Optional
 
 from commands import globals as g
+from commands import install_tree
 from commands.utils import parse_version_specifier
 
 # Module-level cached auth token (lives for the CLI session)
@@ -443,6 +444,40 @@ def get_install_session_id() -> str:
     if not resumed:
         _persist_install_session(_install_session_id)
     return _install_session_id
+
+
+def _unusable_packages(install_base_path: Path, requested, build_type: str) -> list:
+    """Requested packages that are not actually present in the live tree.
+
+    This is the post-switch check. There is no process to probe — raisin_master
+    installs software, it does not run it — so what it verifies is that the
+    thing just made live is complete and readable.
+    """
+    broken = []
+    for name in sorted(requested):
+        package_dir = (
+            install_base_path
+            / name
+            / g.os_type
+            / g.os_version
+            / g.architecture
+            / build_type
+        )
+        try:
+            if not package_dir.is_dir() or not any(package_dir.iterdir()):
+                broken.append(name)
+        except OSError:
+            broken.append(name)
+    return broken
+
+
+def _version_retention() -> int:
+    """How many install trees to keep, including the live one."""
+    raw = os.environ.get("RAISIN_INSTALL_KEEP_VERSIONS", "").strip()
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 2
 
 
 def _utc_now_iso() -> str:
@@ -2284,6 +2319,14 @@ def download_package(
     )
 
     install_session_id = get_install_session_id()
+
+    # Keep the live symlink healthy, but note the limitation: this path writes
+    # into the tree that is already live, so a single-package install has no
+    # atomic switch and no rollback. install.py calls it once per package, so
+    # staging here would mint a version per package. Bringing it under the same
+    # transaction as download_all_from_archive is follow-up work.
+    install_tree.ensure_tree(install_tree.release_for(install_base_path))
+
     record_install_event(
         "started",
         archive_id=archive_id,
@@ -2381,6 +2424,11 @@ def download_all_from_archive(
     """
     platform_str = f"{g.os_type}-{g.os_version}-{g.architecture}"
 
+    release = install_tree.release_for(install_base_path)
+    repaired = install_tree.ensure_tree(release)
+    if repaired:
+        print(f"🔧 {repaired}")
+
     # An explicit name or version from the caller is a deliberate pin and
     # outranks whatever the fleet has assigned. Only ask the server what to run
     # when the caller expressed no preference.
@@ -2431,6 +2479,16 @@ def download_all_from_archive(
     }
     record_install_event("started", **event_context)
 
+    # Everything below lands in a staging tree cloned from the live one.
+    # Nothing the robot runs changes until commit_version() moves the symlink.
+    staging = install_tree.stage_version(release, actual_version)
+    requested = (
+        set(package_filter)
+        if package_filter
+        else {(pkg.get("packageName") or pkg.get("name", "")) for pkg in packages}
+        - {""}
+    )
+
     results = {}
     for pkg in packages:
         name = pkg.get("packageName") or pkg.get("name", "")
@@ -2446,13 +2504,10 @@ def download_all_from_archive(
         tag = pkg.get("tagName") or pkg.get("version", "")
         version = tag.lstrip("vV") if tag else "0.0.0"
 
+        # _extract_and_read_deps removes this directory before unpacking, which
+        # is what breaks the hardlink shared with the previous version.
         install_dir = (
-            install_base_path
-            / name
-            / g.os_type
-            / g.os_version
-            / g.architecture
-            / build_type
+            staging / name / g.os_type / g.os_version / g.architecture / build_type
         )
 
         download_file = (
@@ -2506,17 +2561,73 @@ def download_all_from_archive(
                 "unpack", "unpack_failed", f"could not unpack '{name}'"
             )
 
-    if results:
-        _report_snapshot_from_install_metadata(
-            install_base_path=install_base_path,
-            archive_id=archive_id,
-            archive_name=archive_name,
-            archive_version=actual_version,
-            platform_str=platform_str,
-            build_type=build_type,
-            install_session_id=install_session_id,
-            manifest_hashes=manifest_hashes_by_package_id(packages),
+    missing = sorted(requested - set(results))
+    if missing:
+        # A partial archive is not an installed archive: leave the previous
+        # version live and report why, rather than committing something the
+        # robot was never asked to run.
+        print(
+            f"⚠️ Not committing '{archive_name}' v{actual_version}: "
+            f"{len(missing)} package(s) missing ({', '.join(missing[:3])}"
+            f"{'…' if len(missing) > 3 else ''})."
         )
+        install_tree.discard_staging(release, actual_version)
+        note_install_failure(
+            *(pending_install_failure() or ("unpack", "unpack_failed")),
+            f"incomplete archive install: missing {', '.join(missing)}",
+        )
+        return {}
+
+    install_tree.commit_version(release, actual_version)
+    print(f"🔀 Switched release/install to {archive_name} v{actual_version}.")
+
+    broken = _unusable_packages(install_base_path, requested, build_type)
+    if broken:
+        restored = install_tree.rollback(release)
+        note_install_failure(
+            "health_check",
+            "health_check_failed",
+            f"unusable after switch: {', '.join(broken)}",
+        )
+        if restored:
+            print(
+                f"↩️  Rolled back to v{restored}: {len(broken)} package(s) "
+                "unusable after the switch."
+            )
+            record_install_event(
+                "rolled_back",
+                stage="health_check",
+                error_code="health_check_failed",
+                error_message=f"unusable after switch: {', '.join(broken)}",
+                **event_context,
+            )
+        else:
+            # Nothing to restore, so this is not a rollback — the contract
+            # reserves `rolled_back` for an attempt that came back.
+            print(
+                f"⚠️ {len(broken)} package(s) unusable after the switch and no "
+                "previous version to restore."
+            )
+            record_install_event(
+                "failed",
+                stage="health_check",
+                error_code="health_check_failed",
+                error_message=f"unusable after switch: {', '.join(broken)}",
+                **event_context,
+            )
+        return {}
+
+    _report_snapshot_from_install_metadata(
+        install_base_path=install_base_path,
+        archive_id=archive_id,
+        archive_name=archive_name,
+        archive_version=actual_version,
+        platform_str=platform_str,
+        build_type=build_type,
+        install_session_id=install_session_id,
+        manifest_hashes=manifest_hashes_by_package_id(packages),
+    )
+    install_tree.prune_versions(release, keep=_version_retention())
 
     return results
 

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -11,8 +11,10 @@ All operations fail gracefully — OTA is supplementary, never blocks existing f
 """
 
 import base64
+import errno
 import json
 import os
+import random
 import re
 import hashlib
 import shutil
@@ -66,6 +68,11 @@ _TOKEN_CACHE_FILE = ".ota_token_cache.json"
 
 # Per-install metadata file written after OTA extraction
 _INSTALL_METADATA_FILE = "ota-install.json"
+
+# Correlation id for one install, persisted so a crashed run resumes the same
+# session rather than inventing a new one.
+_INSTALL_SESSION_FILE = ".ota-session.json"
+_INSTALL_SESSION_TTL_SECONDS = 24 * 60 * 60
 
 # Robot API key configuration. The key file is intentionally outside the repo.
 _ROBOT_API_KEY_FILE = "robot-api-key"  # pragma: allowlist secret
@@ -372,12 +379,68 @@ def get_client_version() -> str:
     return DEFAULT_CLIENT_VERSION
 
 
+def _install_session_path() -> Path:
+    return Path(g.script_directory) / "install" / _INSTALL_SESSION_FILE
+
+
+def _read_install_session() -> Optional[str]:
+    """Recover the session an interrupted install was using, if still current."""
+    try:
+        data = json.loads(_install_session_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    session_id = data.get("installSessionId")
+    started_at = data.get("startedAt")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    if not isinstance(started_at, (int, float)):
+        return None
+    if time.time() - started_at > _INSTALL_SESSION_TTL_SECONDS:
+        return None
+    return session_id
+
+
+def _persist_install_session(session_id: str) -> None:
+    path = _install_session_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"installSessionId": session_id, "startedAt": time.time()}),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
 def get_install_session_id() -> str:
-    """Return a stable install session id for this CLI process."""
+    """Return the install session id, resuming an interrupted one if present.
+
+    A retry after a crash has to keep the same id: the server pins download
+    authorization to what desired state resolved at session start, and the
+    partial files on disk belong to that session.
+    """
     global _install_session_id
-    if not _install_session_id:
-        _install_session_id = str(uuid.uuid4())
+    if _install_session_id:
+        return _install_session_id
+
+    resumed = _read_install_session()
+    _install_session_id = resumed or str(uuid.uuid4())
+    if not resumed:
+        _persist_install_session(_install_session_id)
     return _install_session_id
+
+
+def clear_install_session() -> None:
+    """Retire the session so the next install starts a fresh one."""
+    global _install_session_id
+    _install_session_id = None
+    try:
+        _install_session_path().unlink()
+    except OSError:
+        pass
 
 
 def get_archive_name(build_type: str, archive_name: Optional[str] = None) -> str:
@@ -1069,8 +1132,8 @@ def _fetch_archive_with_stable_fallback(
     return None
 
 
-def _stream_download(url: str, download_path: Path, error_context: str = "") -> bool:
-    """Stream download a file from a URL.
+def _stream_download(url: str, download_path: Path, error_context: str = "") -> tuple:
+    """Stream download a file from a URL, with resume, verification and retry.
 
     Args:
         url: Full URL to download from.
@@ -1078,30 +1141,16 @@ def _stream_download(url: str, download_path: Path, error_context: str = "") -> 
         error_context: Context string for error messages (e.g., package name).
 
     Returns:
-        True on success, False on failure.
+        (ok, error_code); error_code is None on success and otherwise a member
+        of the install-event error taxonomy.
     """
     ctx = _get_auth_context()
     if not ctx:
-        return False
+        return (False, ERROR_UNKNOWN)
     _, headers = ctx
-
-    try:
-        download_path.parent.mkdir(parents=True, exist_ok=True)
-        with requests.get(url, headers=headers, stream=True, timeout=60) as resp:
-            resp.raise_for_status()
-            with open(download_path, "wb") as f:
-                for chunk in resp.iter_content(chunk_size=8192):
-                    f.write(chunk)
-        return True
-    except (requests.RequestException, OSError) as e:
-        if download_path.exists():
-            try:
-                download_path.unlink()
-            except OSError:
-                pass
-        context = f" for '{error_context}'" if error_context else ""
-        print(f"⚠️ OTA download failed{context}: {e}")
-        return False
+    return _download_to_path(
+        url, download_path, headers=headers, error_context=error_context
+    )
 
 
 def _robot_auth_headers(install_session_id: Optional[str] = None) -> Optional[dict]:
@@ -1202,6 +1251,258 @@ def _resolve_desired_state(platform_str: str) -> tuple:
     return (False, name, version)
 
 
+class ContentHashMismatch(Exception):
+    """Downloaded bytes did not match the digest the server advertised."""
+
+
+# Error codes from the server's install-event contract
+# (docs/ota-install-event-contract.md). The server treats these as data and
+# never branches on them — classification is the client's job, because the
+# client is the only party that knows what actually happened.
+ERROR_NETWORK = "network"
+ERROR_TIMEOUT = "timeout"
+ERROR_HASH_MISMATCH = "hash_mismatch"
+ERROR_DISK_FULL = "disk_full"
+ERROR_SERVER_ERROR = "server_error"
+ERROR_UNKNOWN = "unknown"
+
+# Retrying only helps when the cause is transient. A 4xx, a full disk or an
+# unclassified failure will answer the same way on the next attempt.
+_RETRYABLE_ERROR_CODES = frozenset(
+    {ERROR_NETWORK, ERROR_TIMEOUT, ERROR_SERVER_ERROR, ERROR_HASH_MISMATCH}
+)
+
+
+def classify_download_error(exc: BaseException) -> str:
+    """Map a download failure onto the install-event error taxonomy."""
+    if isinstance(exc, ContentHashMismatch):
+        return ERROR_HASH_MISMATCH
+    # ConnectTimeout subclasses both Timeout and ConnectionError, so timeout
+    # must be tested first to keep the more specific answer.
+    if isinstance(exc, requests.Timeout):
+        return ERROR_TIMEOUT
+    if isinstance(exc, requests.ConnectionError):
+        return ERROR_NETWORK
+    if isinstance(exc, requests.HTTPError):
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if isinstance(status, int) and 500 <= status < 600:
+            return ERROR_SERVER_ERROR
+        return ERROR_UNKNOWN
+    if isinstance(exc, OSError) and exc.errno == errno.ENOSPC:
+        return ERROR_DISK_FULL
+    return ERROR_UNKNOWN
+
+
+def is_retryable_error_code(error_code: str) -> bool:
+    """Whether backoff should spend another attempt on this failure."""
+    return error_code in _RETRYABLE_ERROR_CODES
+
+
+# Retry/backoff tuning. A synchronised fleet reboots together, so jitter is
+# what keeps the retry burst from arriving in lockstep.
+_BACKOFF_BASE_SECONDS = 1.0
+_BACKOFF_MAX_SECONDS = 30.0
+_MAX_DOWNLOAD_ATTEMPTS = 4
+
+# Partial downloads live beside the target under this suffix, never at the
+# final path — the installer must never see a half-written archive.
+_PART_SUFFIX = ".part"
+
+# Refuse a download that would leave no room to unpack what it just fetched.
+_DISK_HEADROOM_BYTES = 16 * 1024 * 1024
+
+
+def _part_state_path(part_path: Path) -> Path:
+    return part_path.with_name(part_path.name + ".json")
+
+
+def _write_part_state(part_path: Path, content_hash: Optional[str]) -> None:
+    """Record the digest a partial file belongs to, so a later process can resume."""
+    if not content_hash:
+        return
+    try:
+        _part_state_path(part_path).write_text(
+            json.dumps({"contentHash": content_hash}), encoding="utf-8"
+        )
+    except OSError:
+        pass
+
+
+def _read_part_state(part_path: Path) -> Optional[str]:
+    try:
+        data = json.loads(_part_state_path(part_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    value = data.get("contentHash")
+    return value if isinstance(value, str) and value else None
+
+
+def _discard_part(part_path: Path) -> None:
+    for path in (part_path, _part_state_path(part_path)):
+        try:
+            if path.exists():
+                path.unlink()
+        except OSError:
+            pass
+
+
+def _digest_of_prefix(path: Path, length: int):
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        remaining = length
+        while remaining > 0:
+            chunk = f.read(min(8192, remaining))
+            if not chunk:
+                break
+            digest.update(chunk)
+            remaining -= len(chunk)
+    return digest
+
+
+def _announced_body_length(response_headers) -> Optional[int]:
+    """Bytes the server says this response body carries, if it says."""
+    try:
+        return int(response_headers.get("Content-Length"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _assert_disk_space(part_path: Path, response_headers) -> None:
+    """Fail before writing rather than filling the disk and dying mid-stream."""
+    incoming = _announced_body_length(response_headers)
+    if incoming is None:
+        return
+
+    try:
+        free = shutil.disk_usage(part_path.parent).free
+    except OSError:
+        return
+
+    if free < incoming + _DISK_HEADROOM_BYTES:
+        raise OSError(
+            errno.ENOSPC,
+            f"needs {incoming + _DISK_HEADROOM_BYTES} bytes, {free} free",
+        )
+
+
+def _attempt_download(
+    url: str,
+    part_path: Path,
+    download_path: Path,
+    headers: Optional[dict],
+    params: Optional[dict],
+    timeout: int,
+) -> None:
+    """One download attempt. Raises on any failure; renames into place on success."""
+    known_hash = _read_part_state(part_path)
+    try:
+        existing = part_path.stat().st_size
+    except OSError:
+        existing = 0
+
+    # A partial with no recorded digest cannot be validated after resuming, so
+    # it is cheaper to discard it than to risk splicing two different objects.
+    if existing and not known_hash:
+        _discard_part(part_path)
+        existing = 0
+
+    request_headers = dict(headers or {})
+    if existing:
+        request_headers["Range"] = f"bytes={existing}-"
+        request_headers["If-Range"] = f'"{known_hash}"'
+
+    part_path.parent.mkdir(parents=True, exist_ok=True)
+    with requests.get(
+        url, headers=request_headers, params=params, stream=True, timeout=timeout
+    ) as resp:
+        resp.raise_for_status()
+
+        # A 200 in response to a Range request means the object changed and the
+        # server is sending the whole thing — the partial is now garbage.
+        resume_from = existing
+        if resume_from and resp.status_code != 206:
+            _discard_part(part_path)
+            resume_from = 0
+
+        expected = _expected_content_hash(resp.headers)
+        if not expected:
+            print(
+                f"⚠️ OTA server sent no content hash for "
+                f"'{download_path.name}'; download integrity was not verified."
+            )
+        _assert_disk_space(part_path, resp.headers)
+        _write_part_state(part_path, expected)
+
+        digest = (
+            _digest_of_prefix(part_path, resume_from)
+            if resume_from
+            else hashlib.sha256()
+        )
+        received = 0
+        with open(part_path, "ab" if resume_from else "wb") as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                digest.update(chunk)
+                received += len(chunk)
+                f.write(chunk)
+
+        # A connection cut cleanly between chunks raises nothing, so without
+        # this a truncated body would be renamed into place whenever the server
+        # sends no digest to check it against.
+        announced = _announced_body_length(resp.headers)
+        if announced is not None and received < announced:
+            raise requests.ConnectionError(
+                f"incomplete body: got {received} of {announced} bytes"
+            )
+
+    if expected and digest.hexdigest() != expected:
+        _discard_part(part_path)
+        raise ContentHashMismatch(f"expected {expected}, got {digest.hexdigest()}")
+
+    part_path.replace(download_path)
+    _discard_part(part_path)
+
+
+def _download_to_path(
+    url: str,
+    download_path: Path,
+    headers: Optional[dict] = None,
+    params: Optional[dict] = None,
+    error_context: str = "",
+    max_attempts: int = _MAX_DOWNLOAD_ATTEMPTS,
+    timeout: int = 60,
+) -> tuple:
+    """Download to `download_path` with resume, verification and bounded retry.
+
+    Returns `(ok, error_code)`; `error_code` is None on success and otherwise a
+    member of the install-event taxonomy, ready to attach to a failed event.
+    """
+    part_path = download_path.with_name(download_path.name + _PART_SUFFIX)
+    context = f" for '{error_context}'" if error_context else ""
+    error_code = ERROR_UNKNOWN
+
+    for attempt in range(max_attempts):
+        try:
+            _attempt_download(url, part_path, download_path, headers, params, timeout)
+            return (True, None)
+        except (requests.RequestException, OSError, ContentHashMismatch) as e:
+            error_code = classify_download_error(e)
+            print(f"⚠️ OTA download failed{context} [{error_code}]: {e}")
+
+            if not is_retryable_error_code(error_code):
+                break
+            if attempt == max_attempts - 1:
+                break
+
+            window = min(_BACKOFF_BASE_SECONDS * (2**attempt), _BACKOFF_MAX_SECONDS)
+            delay = random.uniform(window / 2, window)
+            print(f"   retrying in {delay:.1f}s ({attempt + 2}/{max_attempts})")
+            time.sleep(delay)
+
+    return (False, error_code)
+
+
 def _expected_content_hash(response_headers) -> Optional[str]:
     """Extract the sha256 the server claims for a download body.
 
@@ -1227,7 +1528,7 @@ def _stream_robot_package_download(
     platform_str: str,
     download_path: Path,
     headers: dict,
-) -> bool:
+) -> tuple:
     """Download a package through the robot-authenticated by-key endpoint."""
     base = get_ota_endpoint().rstrip("/")
     url = f"{base}/robots/me/archives/by-key/packages/{package_id}/download"
@@ -1236,42 +1537,13 @@ def _stream_robot_package_download(
         "platform": platform_str,
         "version": archive_version.lstrip("vV"),
     }
-
-    try:
-        download_path.parent.mkdir(parents=True, exist_ok=True)
-        with requests.get(
-            url, headers=headers, params=params, stream=True, timeout=60
-        ) as resp:
-            resp.raise_for_status()
-            digest = hashlib.sha256()
-            with open(download_path, "wb") as f:
-                for chunk in resp.iter_content(chunk_size=8192):
-                    digest.update(chunk)
-                    f.write(chunk)
-            expected = _expected_content_hash(resp.headers)
-
-        # Nobody is watching an unattended robot install, so a truncated or
-        # corrupted body has to fail here rather than surface later as a
-        # confusing "not a zip file" during extraction.
-        if expected and digest.hexdigest() != expected:
-            raise OSError(
-                f"content hash mismatch (expected {expected}, "
-                f"got {digest.hexdigest()})"
-            )
-        if not expected:
-            print(
-                f"⚠️ OTA server sent no content hash for '{package_name}'; "
-                "download integrity was not verified."
-            )
-        return True
-    except (requests.RequestException, OSError) as e:
-        if download_path.exists():
-            try:
-                download_path.unlink()
-            except OSError:
-                pass
-        print(f"⚠️ Robot OTA download failed for '{package_name}': {e}")
-        return False
+    return _download_to_path(
+        url,
+        download_path,
+        headers=headers,
+        params=params,
+        error_context=package_name,
+    )
 
 
 def _download_package_blob(
@@ -1283,8 +1555,11 @@ def _download_package_blob(
     archive_version: Optional[str] = None,
     platform_str: Optional[str] = None,
     install_session_id: Optional[str] = None,
-) -> bool:
-    """Download a single package blob from an archive."""
+) -> tuple:
+    """Download a single package blob from an archive.
+
+    Returns (ok, error_code); error_code is None on success.
+    """
     robot_headers = _robot_auth_headers(install_session_id)
     if robot_headers and archive_name and archive_version and platform_str:
         return _stream_robot_package_download(
@@ -1722,7 +1997,7 @@ def download_package(
     install_session_id = get_install_session_id()
 
     print(f"⬇️  Downloading '{package_name}' v{version} from OTA server...")
-    if not _download_package_blob(
+    download_ok, _download_error = _download_package_blob(
         archive_id,
         pkg_id,
         package_name,
@@ -1731,7 +2006,8 @@ def download_package(
         archive_version=actual_version,
         platform_str=platform_str,
         install_session_id=install_session_id,
-    ):
+    )
+    if not download_ok:
         return None
 
     install_metadata = _build_archive_install_metadata(
@@ -1872,7 +2148,7 @@ def download_all_from_archive(
         )
 
         print(f"⬇️  Downloading '{name}' v{version} from OTA server...")
-        if not _download_package_blob(
+        download_ok, _download_error = _download_package_blob(
             archive_id,
             pkg_id,
             name,
@@ -1881,7 +2157,8 @@ def download_all_from_archive(
             archive_version=actual_version,
             platform_str=platform_str,
             install_session_id=install_session_id,
-        ):
+        )
+        if not download_ok:
             continue
 
         install_metadata = _build_archive_install_metadata(
@@ -1958,7 +2235,8 @@ def _download_blob_by_hash(blob_hash: str, download_path: Path) -> bool:
     """Download a blob directly by its hash."""
     base = get_ota_endpoint().rstrip("/")
     url = f"{base}/blobs/{blob_hash}/download"
-    return _stream_download(url, download_path, f"blob {blob_hash[:8]}")
+    ok, _error_code = _stream_download(url, download_path, f"blob {blob_hash[:8]}")
+    return ok
 
 
 def download_package_at_timestamp(

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -70,6 +70,10 @@ _INSTALL_METADATA_FILE = "ota-install.json"
 _ROBOT_API_KEY_FILE = "robot-api-key"  # pragma: allowlist secret
 _ROBOT_API_KEY_ENV = "RAISIN_ROBOT_API_KEY"  # pragma: allowlist secret
 _ROBOT_API_KEY_FILE_ENV = "RAISIN_ROBOT_API_KEY_FILE"  # pragma: allowlist secret
+_ROBOT_NODE_ENV = "RAISIN_ROBOT_NODE"
+_ROBOT_NODE_KEY_ENV = "RAISIN_ROBOT_NODE_KEY"
+_ROBOT_CONFIG_FILES = ("configuration_setting.yaml", "secrets.yaml")
+_robot_auth_warning_keys = set()
 
 # Client identity attached to robot OTA audit/history records.
 DEFAULT_CLIENT_VERSION = "raisin-cli"
@@ -110,6 +114,50 @@ def get_ssh_key_path() -> Path:
 
     # 3. Default fallback
     return ssh_dir / "id_ed25519"
+
+
+def _normalize_optional_string(value) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    if not value or value.lower() in {"none", "null"}:
+        return None
+    return value
+
+
+def _load_local_config() -> dict:
+    """Best-effort read of local configuration without enforcing full config validity."""
+    script_dir_path = Path(g.script_directory)
+    for filename in _ROBOT_CONFIG_FILES:
+        config_path = script_dir_path / filename
+        if not config_path.is_file():
+            continue
+        try:
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            return {}
+        return config if isinstance(config, dict) else {}
+    return {}
+
+
+def _get_nested_config_value(config: dict, path: tuple) -> Optional[str]:
+    current = config
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return _normalize_optional_string(current)
+
+
+def _get_local_config_value(paths: tuple) -> Optional[str]:
+    config = _load_local_config()
+    for path in paths:
+        value = _get_nested_config_value(config, path)
+        if value:
+            return value
+    return None
 
 
 def get_robot_api_key_path() -> Path:
@@ -172,17 +220,7 @@ def _cache_robot_api_key(key_path: Path, api_key: Optional[str]) -> None:
     _robot_api_key_cache[key_path] = (_api_key_cache_token(stat_result), api_key)
 
 
-def get_robot_api_key() -> Optional[str]:
-    """Read the robot API key from env or the local key file.
-
-    Env var is useful for CI/tests. The file path is ignored on POSIX systems
-    if group/other permissions are enabled.
-    """
-    env_key = os.environ.get(_ROBOT_API_KEY_ENV, "").strip()
-    if env_key:
-        return env_key
-
-    key_path = get_robot_api_key_path()
+def _read_robot_api_key_file(key_path: Path) -> Optional[str]:
     try:
         stat_result = key_path.stat()
     except FileNotFoundError:
@@ -214,6 +252,66 @@ def get_robot_api_key() -> Optional[str]:
     cached_key = key or None
     _robot_api_key_cache[key_path] = (cache_token, cached_key)
     return cached_key
+
+
+def get_robot_api_key() -> Optional[str]:
+    """Read the robot API key from env or the local key file.
+
+    Resolution order:
+        1. RAISIN_ROBOT_API_KEY
+        2. RAISIN_ROBOT_API_KEY_FILE
+        3. configuration_setting.yaml/secrets.yaml robot.api_key
+        4. ~/.config/raisin/robot-api-key
+
+    File-backed keys are ignored on POSIX systems if group/other permissions
+    are enabled.
+    """
+    env_key = os.environ.get(_ROBOT_API_KEY_ENV, "").strip()
+    if env_key:
+        return env_key
+
+    env_key_file = os.environ.get(_ROBOT_API_KEY_FILE_ENV, "").strip()
+    if env_key_file:
+        return _read_robot_api_key_file(Path(env_key_file).expanduser())
+
+    config_key = _get_local_config_value(
+        (
+            ("robot", "api_key"),
+            ("robot", "apiKey"),
+            ("ota", "robot_api_key"),
+            ("robot_api_key",),
+        )
+    )
+    if config_key:
+        return config_key
+
+    return _read_robot_api_key_file(get_robot_api_key_path())
+
+
+def get_robot_node_key() -> Optional[str]:
+    """Read the robot-local node key required by robot-authenticated endpoints."""
+    for env_name in (_ROBOT_NODE_ENV, _ROBOT_NODE_KEY_ENV):
+        env_value = _normalize_optional_string(os.environ.get(env_name))
+        if env_value:
+            return env_value
+
+    return _get_local_config_value(
+        (
+            ("robot", "node"),
+            ("robot", "node_key"),
+            ("robot", "nodeKey"),
+            ("ota", "robot_node"),
+            ("robot_node",),
+            ("robot_node_key",),
+        )
+    )
+
+
+def _warn_robot_auth_config_once(key: str, message: str) -> None:
+    if key in _robot_auth_warning_keys:
+        return
+    _robot_auth_warning_keys.add(key)
+    print(message)
 
 
 def get_client_version() -> str:
@@ -962,12 +1060,22 @@ def _robot_auth_headers(install_session_id: Optional[str] = None) -> Optional[di
     api_key = get_robot_api_key()
     if not api_key:
         return None
+    node_key = get_robot_node_key()
+    if not node_key:
+        _warn_robot_auth_config_once(
+            "missing_robot_node",
+            "⚠️ Robot API key is configured but robot node is missing "
+            "(set RAISIN_ROBOT_NODE or configuration_setting.yaml robot.node). "
+            "Using legacy OTA authentication instead.",
+        )
+        return None
 
     session_id = install_session_id or get_install_session_id()
     return {
         "Authorization": f"Robot {api_key}",
         "X-Client-Version": get_client_version(),
         "X-Install-Session-Id": session_id,
+        "X-Robot-Node": node_key,
     }
 
 
@@ -1142,12 +1250,14 @@ def _snapshot_package_from_metadata(metadata: dict) -> Optional[dict]:
     package_id = str(metadata.get("packageId") or "").strip()
     package_name = str(metadata.get("packageName") or "").strip()
     version = str(metadata.get("packageVersion") or "").strip().lstrip("vV")
-    if not package_id or not package_name or not version:
+    manifest_hash = str(metadata.get("manifestHash") or "").strip()
+    if not package_id or not package_name or not version or not manifest_hash:
         return None
     return {
         "packageId": package_id,
         "packageName": package_name,
         "version": version,
+        "manifestHash": manifest_hash,
     }
 
 
@@ -1203,7 +1313,7 @@ def report_software_snapshot(
     session_id = install_session_id or get_install_session_id()
     payload = {
         "archiveId": archive_id,
-        "packages": packages,
+        "archivePackages": packages,
         "installSessionId": session_id,
         "clientVersion": get_client_version(),
     }

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -311,6 +311,62 @@ def get_install_session_id() -> str:
     return _install_session_id
 
 
+def _archive_identity_from_tree(
+    install_base_path: Path, build_type: str
+) -> Optional[tuple]:
+    """(archive_id, name, version) recorded in whatever tree is live right now.
+
+    Read back rather than remembered: after a rollback the live tree is the
+    *previous* archive, and only its own install metadata knows which one that
+    was. A tree adopted from a pre-versioning install has no such metadata and
+    yields None.
+    """
+    pattern = f"*/*/*/*/{build_type}/{_INSTALL_METADATA_FILE}"
+    for metadata_path in sorted(Path(install_base_path).glob(pattern)):
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(metadata, dict) or metadata.get("source") != "archive":
+            continue
+
+        archive_id = _normalize_optional_string(metadata.get("archiveId"))
+        name = _normalize_optional_string(metadata.get("archiveName"))
+        version = _normalize_optional_string(metadata.get("archiveVersion"))
+        if archive_id and name and version:
+            return (archive_id, name, version)
+    return None
+
+
+def _report_restored_snapshot(
+    install_base_path: Path, build_type: str, install_session_id: str
+) -> None:
+    """Tell the server what the robot is running after a rollback.
+
+    A snapshot is otherwise only sent on a successful commit, so a rollback
+    that stays silent leaves the fleet view showing the version that was just
+    reverted — software the robot is no longer running.
+    """
+    identity = _archive_identity_from_tree(install_base_path, build_type)
+    if identity is None:
+        print(
+            "⚠️ Rolled back to a tree with no archive metadata; the server "
+            "still lists the version that was reverted."
+        )
+        return
+
+    archive_id, archive_name, archive_version = identity
+    _report_snapshot_from_install_metadata(
+        install_base_path=install_base_path,
+        archive_id=archive_id,
+        archive_name=archive_name,
+        archive_version=archive_version,
+        platform_str=_ctx().platform,
+        build_type=build_type,
+        install_session_id=install_session_id,
+    )
+
+
 def _unusable_packages(install_base_path: Path, requested, build_type: str) -> list:
     """Requested packages that are not actually present in the live tree.
 
@@ -2490,6 +2546,7 @@ def download_all_from_archive(
                 error_message=f"unusable after switch: {', '.join(broken)}",
                 **event_context,
             )
+            _report_restored_snapshot(install_base_path, build_type, install_session_id)
         else:
             # Nothing to restore, so this is not a rollback — the contract
             # reserves `rolled_back` for an attempt that came back.

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -132,11 +132,9 @@ def save_robot_api_key(api_key: str, path: Optional[Path] = None) -> Path:
         pass
 
     temp_path = target.with_name(f".{target.name}.tmp")
-    temp_path.write_text(key + "\n", encoding="utf-8")
-    try:
-        os.chmod(temp_path, 0o600)
-    except OSError:
-        pass
+    fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(key + "\n")
     temp_path.replace(target)
     try:
         os.chmod(target, 0o600)
@@ -902,7 +900,7 @@ def _stream_download(url: str, download_path: Path, error_context: str = "") -> 
                 for chunk in resp.iter_content(chunk_size=8192):
                     f.write(chunk)
         return True
-    except requests.RequestException as e:
+    except (requests.RequestException, OSError) as e:
         context = f" for '{error_context}'" if error_context else ""
         print(f"⚠️ OTA download failed{context}: {e}")
         return False
@@ -950,7 +948,7 @@ def _stream_robot_package_download(
                 for chunk in resp.iter_content(chunk_size=8192):
                     f.write(chunk)
         return True
-    except requests.RequestException as e:
+    except (requests.RequestException, OSError) as e:
         if download_path.exists():
             try:
                 download_path.unlink()
@@ -1117,7 +1115,9 @@ def _collect_archive_snapshot_packages(
     for metadata_path in sorted(install_base_path.glob(metadata_pattern)):
         try:
             metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+            if not isinstance(metadata, dict):
+                continue
+        except (OSError, ValueError):
             continue
 
         if metadata.get("source") != "archive":

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -1560,11 +1560,21 @@ def _resolve_desired_state(platform_str: str) -> tuple:
 
     target = state.get("target")
     if not isinstance(target, dict):
-        if state.get("reason") == "target_unresolved":
+        reason = state.get("reason")
+        if reason == "target_unresolved":
             detail = state.get("unresolvedDetail") or "no detail given"
             print(
                 "⚠️ The OTA server has an archive assigned to this node but "
                 f"could not resolve it: {detail}."
+            )
+        elif reason == "no_target":
+            # Say this plainly: an unassigned node is in a normal state, but
+            # the legacy-route warnings that follow read as a broken
+            # credential rather than as "nobody told this robot what to run".
+            print(
+                "ℹ️  No archive is assigned to this robot node yet. "
+                "Assign one on the OTA server to install as this robot; "
+                "continuing on the legacy route, which authenticates as a user."
             )
         return (False, None, None, None)
 

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -1538,18 +1538,25 @@ def fetch_robot_desired_state() -> Optional[dict]:
 def _resolve_desired_state(platform_str: str) -> tuple:
     """Fold the server's desired state into an archive selection.
 
-    Returns (halted, archive_name, archive_version). Name and version are None
-    whenever the server has no usable opinion, leaving the caller's own
+    Returns (halted, archive_name, archive_version, manifest). Name and version
+    are None whenever the server has no usable opinion, leaving the caller's own
     selection untouched.
+
+    `manifest` is the same `(packages, archive_id, version)` tuple
+    `_fetch_archive_manifest` produces, built from `target.packages`. That field
+    is what lets a robot install with its API key alone: the per-package
+    download endpoint needs a packageId, and every manifest route is closed to a
+    robot credential. A server that does not send it yields None here, and the
+    caller falls back to the JWT route.
     """
     state = fetch_robot_desired_state()
     if not state:
-        return (False, None, None)
+        return (False, None, None, None)
 
     if state.get("halt"):
         sources = ", ".join(state.get("haltSources") or []) or "an unknown scope"
         print(f"⛔ OTA installs are halted for this node by: {sources}.")
-        return (True, None, None)
+        return (True, None, None, None)
 
     target = state.get("target")
     if not isinstance(target, dict):
@@ -1559,7 +1566,7 @@ def _resolve_desired_state(platform_str: str) -> tuple:
                 "⚠️ The OTA server has an archive assigned to this node but "
                 f"could not resolve it: {detail}."
             )
-        return (False, None, None)
+        return (False, None, None, None)
 
     target_platform = _normalize_optional_string(target.get("platform"))
     if target_platform and target_platform != platform_str:
@@ -1567,18 +1574,25 @@ def _resolve_desired_state(platform_str: str) -> tuple:
             f"⚠️ OTA desired state targets '{target_platform}' but this node "
             f"is '{platform_str}'. Ignoring it."
         )
-        return (False, None, None)
+        return (False, None, None, None)
 
     name = _normalize_optional_string(target.get("name"))
     version = _normalize_optional_string(target.get("version"))
     if not name or not version:
-        return (False, None, None)
+        return (False, None, None, None)
 
     print(
         f"🛰️  OTA desired state ({state.get('reason')}): "
         f"{name} v{version} on {target_platform or platform_str}"
     )
-    return (False, name, version)
+
+    manifest = None
+    packages = target.get("packages")
+    archive_id = _normalize_optional_string(target.get("archiveId"))
+    if isinstance(packages, list) and packages and archive_id:
+        manifest = (packages, archive_id, version)
+
+    return (False, name, version, manifest)
 
 
 class ContentHashMismatch(Exception):
@@ -2461,15 +2475,22 @@ def download_all_from_archive(
     caller_pinned_archive = bool(archive_name) or bool(archive_version)
     archive_name = get_archive_name(build_type, archive_name)
 
+    desired_manifest = None
     if not caller_pinned_archive:
-        halted, desired_name, desired_version = _resolve_desired_state(platform_str)
+        halted, desired_name, desired_version, desired_manifest = (
+            _resolve_desired_state(platform_str)
+        )
         if halted:
             return {}
         if desired_name and desired_version:
             archive_name, archive_version = desired_name, desired_version
 
-    # Selection priority: archive_version > tag > legacy latest.
-    if archive_version:
+    # Selection priority: desired state > archive_version > tag > legacy latest.
+    # The desired-state manifest comes first because it is the only route a
+    # robot credential can read; everything below it needs a user token.
+    if desired_manifest:
+        manifest = desired_manifest
+    elif archive_version:
         manifest = _fetch_archive_manifest(archive_name, platform_str, archive_version)
     elif tag:
         manifest = _fetch_archive_with_stable_fallback(archive_name, platform_str, tag)

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -10,6 +10,7 @@ Uses DEFAULT_OTA_ENDPOINT by default. Override with RAISIN_OTA_ENDPOINT env var.
 All operations fail gracefully — OTA is supplementary, never blocks existing flows.
 """
 
+import atexit
 import base64
 import json
 import os
@@ -46,6 +47,11 @@ _archive_cache = {}
 # Correlates all OTA package downloads and the final software snapshot from
 # one CLI process.
 _install_session_id = None
+
+# Debounces per-package installs into one software snapshot report per archive
+# at the end of the CLI process.
+_pending_snapshot_reports = {}
+_pending_snapshot_report_registered = False
 
 # Default archive name prefix (build_type is appended for debug)
 DEFAULT_ARCHIVE_NAME = "raisin-robot"
@@ -139,7 +145,7 @@ def save_robot_api_key(api_key: str, path: Optional[Path] = None) -> Path:
         temp_path.replace(target)
     finally:
         try:
-            temp_path.unlink()
+            temp_path.unlink(missing_ok=True)
         except OSError:
             pass
 
@@ -908,6 +914,11 @@ def _stream_download(url: str, download_path: Path, error_context: str = "") -> 
                     f.write(chunk)
         return True
     except (requests.RequestException, OSError) as e:
+        if download_path.exists():
+            try:
+                download_path.unlink()
+            except OSError:
+                pass
         context = f" for '{error_context}'" if error_context else ""
         print(f"⚠️ OTA download failed{context}: {e}")
         return False
@@ -1190,6 +1201,43 @@ def report_software_snapshot(
         return False
 
 
+def _register_pending_snapshot_flush() -> None:
+    global _pending_snapshot_report_registered
+    if _pending_snapshot_report_registered:
+        return
+    atexit.register(flush_pending_snapshot_reports)
+    _pending_snapshot_report_registered = True
+
+
+def _queue_snapshot_report(
+    install_base_path: Path,
+    archive_id: str,
+    archive_name: str,
+    archive_version: Optional[str],
+    platform_str: str,
+    build_type: str,
+    install_session_id: str,
+) -> None:
+    key = (archive_id, platform_str, build_type, install_session_id)
+    _pending_snapshot_reports[key] = {
+        "install_base_path": install_base_path,
+        "archive_id": archive_id,
+        "archive_name": archive_name,
+        "archive_version": archive_version,
+        "platform_str": platform_str,
+        "build_type": build_type,
+        "install_session_id": install_session_id,
+    }
+    _register_pending_snapshot_flush()
+
+
+def flush_pending_snapshot_reports() -> None:
+    reports = list(_pending_snapshot_reports.values())
+    _pending_snapshot_reports.clear()
+    for report in reports:
+        _report_snapshot_from_install_metadata(**report)
+
+
 def _report_snapshot_from_install_metadata(
     install_base_path: Path,
     archive_id: str,
@@ -1369,7 +1417,7 @@ def download_package(
         install_metadata=install_metadata,
     )
     if result:
-        _report_snapshot_from_install_metadata(
+        _queue_snapshot_report(
             install_base_path=install_base_path,
             archive_id=archive_id,
             archive_name=archive_name,

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -10,7 +10,6 @@ Uses DEFAULT_OTA_ENDPOINT by default. Override with RAISIN_OTA_ENDPOINT env var.
 All operations fail gracefully — OTA is supplementary, never blocks existing flows.
 """
 
-import atexit
 import base64
 import json
 import os
@@ -51,7 +50,9 @@ _install_session_id = None
 # Debounces per-package installs into one software snapshot report per archive
 # at the end of the CLI process.
 _pending_snapshot_reports = {}
-_pending_snapshot_report_registered = False
+
+# Caches file-backed robot API keys by path and file stat metadata.
+_robot_api_key_cache = {}
 
 # Default archive name prefix (build_type is appended for debug)
 DEFAULT_ARCHIVE_NAME = "raisin-robot"
@@ -132,10 +133,6 @@ def save_robot_api_key(api_key: str, path: Optional[Path] = None) -> Path:
 
     target = Path(path).expanduser() if path else get_robot_api_key_path()
     target.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        os.chmod(target.parent, 0o700)
-    except OSError:
-        pass
 
     temp_path = target.with_name(f".{target.name}.tmp")
     try:
@@ -153,7 +150,25 @@ def save_robot_api_key(api_key: str, path: Optional[Path] = None) -> Path:
         os.chmod(target, 0o600)
     except OSError:
         pass
+    _cache_robot_api_key(target, key)
     return target
+
+
+def _api_key_cache_token(stat_result) -> tuple:
+    return (
+        stat_result.st_mtime_ns,
+        stat_result.st_size,
+        stat_result.st_mode & 0o777,
+    )
+
+
+def _cache_robot_api_key(key_path: Path, api_key: Optional[str]) -> None:
+    try:
+        stat_result = key_path.stat()
+    except OSError:
+        _robot_api_key_cache.pop(key_path, None)
+        return
+    _robot_api_key_cache[key_path] = (_api_key_cache_token(stat_result), api_key)
 
 
 def get_robot_api_key() -> Optional[str]:
@@ -168,19 +183,36 @@ def get_robot_api_key() -> Optional[str]:
 
     key_path = get_robot_api_key_path()
     try:
-        if not key_path.is_file():
-            return None
-        if os.name == "posix" and (key_path.stat().st_mode & 0o077):
-            print(
-                "⚠️ Ignoring robot API key file with insecure permissions: "
-                f"{key_path} (run: chmod 600 {key_path})"
-            )
-            return None
-        key = key_path.read_text(encoding="utf-8").strip()
-        return key or None
+        stat_result = key_path.stat()
+    except FileNotFoundError:
+        _robot_api_key_cache.pop(key_path, None)
+        return None
     except OSError as e:
         print(f"⚠️ Failed to read robot API key file '{key_path}': {e}")
         return None
+
+    cache_token = _api_key_cache_token(stat_result)
+    cached = _robot_api_key_cache.get(key_path)
+    if cached and cached[0] == cache_token:
+        return cached[1]
+
+    if os.name == "posix" and (stat_result.st_mode & 0o077):
+        print(
+            "⚠️ Ignoring robot API key file with insecure permissions: "
+            f"{key_path} (run: chmod 600 {key_path})"
+        )
+        _robot_api_key_cache[key_path] = (cache_token, None)
+        return None
+
+    try:
+        key = key_path.read_text(encoding="utf-8").strip()
+    except OSError as e:
+        print(f"⚠️ Failed to read robot API key file '{key_path}': {e}")
+        return None
+
+    cached_key = key or None
+    _robot_api_key_cache[key_path] = (cache_token, cached_key)
+    return cached_key
 
 
 def get_client_version() -> str:
@@ -1201,14 +1233,6 @@ def report_software_snapshot(
         return False
 
 
-def _register_pending_snapshot_flush() -> None:
-    global _pending_snapshot_report_registered
-    if _pending_snapshot_report_registered:
-        return
-    atexit.register(flush_pending_snapshot_reports)
-    _pending_snapshot_report_registered = True
-
-
 def _queue_snapshot_report(
     install_base_path: Path,
     archive_id: str,
@@ -1228,7 +1252,6 @@ def _queue_snapshot_report(
         "build_type": build_type,
         "install_session_id": install_session_id,
     }
-    _register_pending_snapshot_flush()
 
 
 def flush_pending_snapshot_reports() -> None:

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -81,6 +81,11 @@ _INSTALL_EVENT_STATE_FILE = ".ota-install-events.state.json"
 _INSTALL_EVENT_BATCH_LIMIT = 100
 _TERMINAL_EVENT_TYPES = frozenset({"succeeded", "failed", "rolled_back"})
 
+# First failure of the current attempt. A terminal event means the attempt
+# finished, so the decision is deferred to the end of the run instead of being
+# emitted from inside the package loop while downloads are still going.
+_pending_install_failure = None
+
 # Robot API key configuration. The key file is intentionally outside the repo.
 _ROBOT_API_KEY_FILE = "robot-api-key"  # pragma: allowlist secret
 _ROBOT_API_KEY_ENV = "RAISIN_ROBOT_API_KEY"  # pragma: allowlist secret
@@ -523,6 +528,61 @@ def _mark_install_event(session_id: str, marker: str) -> None:
         pass
 
 
+def note_install_failure(
+    stage: str, error_code: Optional[str], message: Optional[str] = None
+) -> None:
+    """Remember why this attempt is going to fail, without ending it yet.
+
+    The first cause wins: an attempt reports one terminal event, and the first
+    failure is what explains the rest.
+    """
+    global _pending_install_failure
+    if _pending_install_failure is None:
+        _pending_install_failure = (stage, error_code or ERROR_UNKNOWN, message)
+
+
+def pending_install_failure() -> Optional[tuple]:
+    """(stage, error_code) of this attempt's first failure, if any."""
+    if _pending_install_failure is None:
+        return None
+    return (_pending_install_failure[0], _pending_install_failure[1])
+
+
+def clear_pending_install_failure() -> None:
+    global _pending_install_failure
+    _pending_install_failure = None
+
+
+def install_attempt_started() -> bool:
+    """Whether this session already reported a `started` event."""
+    return _install_event_marker_seen(get_install_session_id(), "started")
+
+
+def report_install_outcome(overall_success: bool) -> Optional[dict]:
+    """Close the attempt with exactly one terminal event.
+
+    Only the caller knows whether the run as a whole worked, and a noted
+    failure outranks it: `install_command` returns True when *any* package
+    landed, so a partial archive install would otherwise report success.
+    """
+    if not install_attempt_started():
+        return None
+
+    failure = _pending_install_failure
+    if failure is not None:
+        stage, error_code, message = failure
+        return record_install_event(
+            "failed", stage=stage, error_code=error_code, error_message=message
+        )
+    if overall_success:
+        return record_install_event("succeeded")
+    return record_install_event(
+        "failed",
+        error_code=ERROR_UNKNOWN,
+        error_message="install did not complete",
+    )
+
+
 def record_install_event(
     event_type: str,
     stage: Optional[str] = None,
@@ -631,6 +691,7 @@ def flush_install_events() -> bool:
 def clear_install_session() -> None:
     """Retire the session so the next install starts a fresh one."""
     global _install_session_id
+    clear_pending_install_failure()
     retired = _install_session_id
     _install_session_id = None
     try:
@@ -1569,6 +1630,15 @@ def _digest_of_prefix(path: Path, length: int):
     return digest
 
 
+def _content_range_start(response_headers) -> Optional[int]:
+    """First byte offset of a 206 slice, per `Content-Range: bytes <s>-<e>/<t>`."""
+    raw = response_headers.get("Content-Range")
+    if not isinstance(raw, str):
+        return None
+    match = re.match(r"\s*bytes\s+(\d+)-", raw)
+    return int(match.group(1)) if match else None
+
+
 def _announced_body_length(response_headers) -> Optional[int]:
     """Bytes the server says this response body carries, if it says."""
     try:
@@ -1633,6 +1703,17 @@ def _attempt_download(
         if resume_from and resp.status_code != 206:
             _discard_part(part_path)
             resume_from = 0
+
+        # A slice that does not begin where we asked would be appended at the
+        # wrong offset; the hash check catches it only after the whole body has
+        # been written, and blames the wrong thing.
+        if resume_from:
+            start = _content_range_start(resp.headers)
+            if start is not None and start != resume_from:
+                _discard_part(part_path)
+                raise requests.ConnectionError(
+                    f"server resumed at byte {start}, expected {resume_from}"
+                )
 
         expected = _expected_content_hash(resp.headers)
         if not expected:
@@ -2203,6 +2284,14 @@ def download_package(
     )
 
     install_session_id = get_install_session_id()
+    record_install_event(
+        "started",
+        archive_id=archive_id,
+        archive_name=archive_name,
+        archive_version=actual_version,
+        platform=platform_str,
+        install_session_id=install_session_id,
+    )
 
     print(f"⬇️  Downloading '{package_name}' v{version} from OTA server...")
     download_ok, _download_error = _download_package_blob(
@@ -2216,6 +2305,9 @@ def download_package(
         install_session_id=install_session_id,
     )
     if not download_ok:
+        note_install_failure(
+            "download", _download_error, f"download of '{package_name}' failed"
+        )
         return None
 
     install_metadata = _build_archive_install_metadata(
@@ -2241,6 +2333,10 @@ def download_package(
         version,
         install_metadata=install_metadata,
     )
+    if not result:
+        note_install_failure(
+            "unpack", "unpack_failed", f"could not unpack '{package_name}'"
+        )
     if result:
         _queue_snapshot_report(
             install_base_path=install_base_path,
@@ -2375,12 +2471,8 @@ def download_all_from_archive(
             install_session_id=install_session_id,
         )
         if not download_ok:
-            record_install_event(
-                "failed",
-                stage="download",
-                error_code=_download_error or ERROR_UNKNOWN,
-                error_message=f"download of '{name}' failed",
-                **event_context,
+            note_install_failure(
+                "download", _download_error, f"download of '{name}' failed"
             )
             continue
 
@@ -2410,12 +2502,8 @@ def download_all_from_archive(
         if result:
             results[name] = result
         else:
-            record_install_event(
-                "failed",
-                stage="unpack",
-                error_code="unpack_failed",
-                error_message=f"could not unpack '{name}'",
-                **event_context,
+            note_install_failure(
+                "unpack", "unpack_failed", f"could not unpack '{name}'"
             )
 
     if results:

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -142,7 +142,8 @@ def save_robot_api_key(api_key: str, path: Optional[Path] = None) -> Path:
         temp_path.replace(target)
     finally:
         try:
-            temp_path.unlink(missing_ok=True)
+            if temp_path.exists():
+                temp_path.unlink()
         except OSError:
             pass
 
@@ -1157,10 +1158,7 @@ def _collect_archive_snapshot_packages(
     build_type: str,
 ) -> list:
     """Collect currently installed package metadata for an archive."""
-    metadata_pattern = (
-        f"*/{g.os_type}/{g.os_version}/{g.architecture}/{build_type}/"
-        f"{_INSTALL_METADATA_FILE}"
-    )
+    metadata_pattern = f"*/*/*/*/{build_type}/{_INSTALL_METADATA_FILE}"
     packages_by_id = {}
     for metadata_path in sorted(install_base_path.glob(metadata_pattern)):
         try:

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -1652,6 +1652,10 @@ _MAX_DOWNLOAD_ATTEMPTS = 4
 # final path — the installer must never see a half-written archive.
 _PART_SUFFIX = ".part"
 
+# A partial nobody came back for is not worth resuming: the archive may have
+# moved on, and nothing else ever removes it.
+_PART_MAX_AGE_SECONDS = 24 * 60 * 60
+
 # Refuse a download that would leave no room to unpack what it just fetched.
 _DISK_HEADROOM_BYTES = 16 * 1024 * 1024
 
@@ -1760,6 +1764,15 @@ def _attempt_download(
     if existing and not known_hash:
         _discard_part(part_path)
         existing = 0
+
+    if existing:
+        try:
+            age = time.time() - part_path.stat().st_mtime
+        except OSError:
+            age = 0
+        if age > _PART_MAX_AGE_SECONDS:
+            _discard_part(part_path)
+            existing = 0
 
     request_headers = dict(headers or {})
     if existing:

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -132,10 +132,17 @@ def save_robot_api_key(api_key: str, path: Optional[Path] = None) -> Path:
         pass
 
     temp_path = target.with_name(f".{target.name}.tmp")
-    fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        f.write(key + "\n")
-    temp_path.replace(target)
+    try:
+        fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(key + "\n")
+        temp_path.replace(target)
+    finally:
+        try:
+            temp_path.unlink()
+        except OSError:
+            pass
+
     try:
         os.chmod(target, 0o600)
     except OSError:

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -74,6 +74,13 @@ _INSTALL_METADATA_FILE = "ota-install.json"
 _INSTALL_SESSION_FILE = ".ota-session.json"
 _INSTALL_SESSION_TTL_SECONDS = 24 * 60 * 60
 
+# Install events are buffered on disk so an offline robot still reports what
+# happened once it can reach the server again.
+_INSTALL_EVENT_QUEUE_FILE = ".ota-install-events.jsonl"
+_INSTALL_EVENT_STATE_FILE = ".ota-install-events.state.json"
+_INSTALL_EVENT_BATCH_LIMIT = 100
+_TERMINAL_EVENT_TYPES = frozenset({"succeeded", "failed", "rolled_back"})
+
 # Robot API key configuration. The key file is intentionally outside the repo.
 _ROBOT_API_KEY_FILE = "robot-api-key"  # pragma: allowlist secret
 _ROBOT_API_KEY_ENV = "RAISIN_ROBOT_API_KEY"  # pragma: allowlist secret
@@ -433,12 +440,213 @@ def get_install_session_id() -> str:
     return _install_session_id
 
 
+def _utc_now_iso() -> str:
+    """Client clock for `occurredAt`, at millisecond resolution.
+
+    Whole seconds would let two events of one attempt tie, and the server
+    orders a delayed batch by this field.
+    """
+    now = time.time()
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(now))
+    return f"{stamp}.{int(now % 1 * 1000):03d}Z"
+
+
+def _install_event_queue_path() -> Path:
+    return Path(g.script_directory) / "install" / _INSTALL_EVENT_QUEUE_FILE
+
+
+def _install_event_state_path() -> Path:
+    return Path(g.script_directory) / "install" / _INSTALL_EVENT_STATE_FILE
+
+
+def _read_install_event_queue() -> list:
+    """Read the buffered events, skipping any line corruption."""
+    try:
+        raw = _install_event_queue_path().read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return []
+
+    events = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+def _write_install_event_queue(events: list) -> None:
+    path = _install_event_queue_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("".join(json.dumps(e) + "\n" for e in events), encoding="utf-8")
+    except OSError as e:
+        print(f"⚠️ Failed to write OTA install-event queue: {e}")
+
+
+def _append_install_event(event: dict) -> None:
+    path = _install_event_queue_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(event) + "\n")
+    except OSError as e:
+        print(f"⚠️ Failed to buffer OTA install event: {e}")
+
+
+def _read_install_event_state() -> dict:
+    try:
+        data = json.loads(_install_event_state_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _install_event_marker_seen(session_id: str, marker: str) -> bool:
+    return bool(_read_install_event_state().get(session_id, {}).get(marker))
+
+
+def _mark_install_event(session_id: str, marker: str) -> None:
+    """Persist the marker so a restarted process does not re-emit the event."""
+    state = _read_install_event_state()
+    state.setdefault(session_id, {})[marker] = True
+    path = _install_event_state_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def record_install_event(
+    event_type: str,
+    stage: Optional[str] = None,
+    error_code: Optional[str] = None,
+    error_message: Optional[str] = None,
+    attempt: Optional[int] = None,
+    archive_id: Optional[str] = None,
+    archive_name: Optional[str] = None,
+    archive_version: Optional[str] = None,
+    platform: Optional[str] = None,
+    detail: Optional[dict] = None,
+    install_session_id: Optional[str] = None,
+) -> Optional[dict]:
+    """Buffer one install-attempt event.
+
+    An attempt emits exactly one `started` and exactly one terminal event, so
+    the guard is persisted rather than held in memory: a crashed run that
+    resumes its session must not report a second `started`.
+
+    Returns the event, or None when the guard suppressed it.
+    """
+    session_id = install_session_id or get_install_session_id()
+    marker = "terminal" if event_type in _TERMINAL_EVENT_TYPES else event_type
+    if marker in ("started", "terminal") and _install_event_marker_seen(
+        session_id, marker
+    ):
+        return None
+
+    event = {
+        "eventId": str(uuid.uuid4()),
+        "installSessionId": session_id,
+        "eventType": event_type,
+        "occurredAt": _utc_now_iso(),
+        "clientVersion": get_client_version(),
+    }
+    for key, value in (
+        ("stage", stage),
+        ("errorCode", error_code),
+        ("errorMessage", error_message),
+        ("attempt", attempt),
+        ("archiveId", archive_id),
+        ("archiveName", archive_name),
+        ("archiveVersion", archive_version),
+        ("platform", platform),
+        ("detail", detail),
+    ):
+        if value is not None:
+            event[key] = value
+
+    _append_install_event(event)
+    if marker in ("started", "terminal"):
+        _mark_install_event(session_id, marker)
+    return event
+
+
+def flush_install_events() -> bool:
+    """Send buffered install events, keeping anything the server did not ack.
+
+    Returns True only when the queue is empty afterwards, so an offline robot
+    simply tries again on the next run.
+    """
+    remaining = _read_install_event_queue()
+    if not remaining:
+        return True
+
+    headers = _robot_auth_headers()
+    if not headers:
+        return False
+
+    request_headers = dict(headers)
+    request_headers["Content-Type"] = "application/json"
+    base = get_ota_endpoint().rstrip("/")
+    url = f"{base}/robots/me/install-events"
+
+    while remaining:
+        batch = remaining[:_INSTALL_EVENT_BATCH_LIMIT]
+        try:
+            resp = requests.post(
+                url, headers=request_headers, json={"events": batch}, timeout=15
+            )
+            resp.raise_for_status()
+            data = _unwrap_response(resp.json()) or {}
+        except (requests.RequestException, ValueError) as e:
+            print(f"⚠️ Failed to report OTA install events: {e}")
+            break
+
+        acks = data.get("acks") if isinstance(data, dict) else None
+        acked = {
+            ack.get("eventId")
+            for ack in (acks or [])
+            if isinstance(ack, dict) and ack.get("eventId")
+        }
+        # A response that acknowledges nothing we sent would loop forever.
+        if not acked:
+            print("⚠️ OTA server acknowledged no install events; keeping the queue.")
+            break
+
+        remaining = [e for e in remaining if e.get("eventId") not in acked]
+
+    _write_install_event_queue(remaining)
+    if remaining:
+        print(f"ℹ️  {len(remaining)} OTA install event(s) buffered for a later run.")
+    return not remaining
+
+
 def clear_install_session() -> None:
     """Retire the session so the next install starts a fresh one."""
     global _install_session_id
+    retired = _install_session_id
     _install_session_id = None
     try:
         _install_session_path().unlink()
+    except OSError:
+        pass
+
+    # Drop the once-per-session guards too, or the state file grows for the
+    # life of the robot.
+    if not retired:
+        return
+    state = _read_install_event_state()
+    if state.pop(retired, None) is None:
+        return
+    try:
+        _install_event_state_path().write_text(json.dumps(state), encoding="utf-8")
     except OSError:
         pass
 
@@ -2118,6 +2326,14 @@ def download_all_from_archive(
 
     print(f"📦 Using archive: {archive_name} v{actual_version or 'latest'}")
     install_session_id = get_install_session_id()
+    event_context = {
+        "archive_id": archive_id,
+        "archive_name": archive_name,
+        "archive_version": actual_version,
+        "platform": platform_str,
+        "install_session_id": install_session_id,
+    }
+    record_install_event("started", **event_context)
 
     results = {}
     for pkg in packages:
@@ -2159,6 +2375,13 @@ def download_all_from_archive(
             install_session_id=install_session_id,
         )
         if not download_ok:
+            record_install_event(
+                "failed",
+                stage="download",
+                error_code=_download_error or ERROR_UNKNOWN,
+                error_message=f"download of '{name}' failed",
+                **event_context,
+            )
             continue
 
         install_metadata = _build_archive_install_metadata(
@@ -2186,6 +2409,14 @@ def download_all_from_archive(
         )
         if result:
             results[name] = result
+        else:
+            record_install_event(
+                "failed",
+                stage="unpack",
+                error_code="unpack_failed",
+                error_message=f"could not unpack '{name}'",
+                **event_context,
+            )
 
     if results:
         _report_snapshot_from_install_metadata(

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -257,8 +257,33 @@ def get_ssh_key_path() -> Path:
     return ssh_dir / "id_ed25519"
 
 
+def _robot_state_path(filename: str) -> Path:
+    """Robot state that has to outlive a build.
+
+    `<workspace>/install` is deleted and recreated by every full build
+    (`setup.py`), so anything kept there is gone by the next run. That is fatal
+    for the event queue in particular: buffering exists so a robot that was
+    offline when an install failed still reports on a later run, and a build in
+    between must not erase what it was going to say. `release/` already holds
+    the install tree's own state and no build removes it.
+
+    A file left at the old location is carried over rather than abandoned: an
+    upgrade must not throw away reports the previous client had buffered.
+    """
+    current = _ctx().workspace / "release" / filename
+    legacy = _ctx().workspace / "install" / filename
+    if legacy.exists() and not current.exists():
+        try:
+            current.parent.mkdir(parents=True, exist_ok=True)
+            legacy.replace(current)
+        except OSError:
+            # Keep reading the old copy rather than losing it.
+            return legacy
+    return current
+
+
 def _install_session_path() -> Path:
-    return _ctx().workspace / "install" / _INSTALL_SESSION_FILE
+    return _robot_state_path(_INSTALL_SESSION_FILE)
 
 
 def _read_install_session() -> Optional[str]:
@@ -406,11 +431,11 @@ def _utc_now_iso() -> str:
 
 
 def _install_event_queue_path() -> Path:
-    return _ctx().workspace / "install" / _INSTALL_EVENT_QUEUE_FILE
+    return _robot_state_path(_INSTALL_EVENT_QUEUE_FILE)
 
 
 def _install_event_state_path() -> Path:
-    return _ctx().workspace / "install" / _INSTALL_EVENT_STATE_FILE
+    return _robot_state_path(_INSTALL_EVENT_STATE_FILE)
 
 
 def _read_install_event_queue() -> list:
@@ -637,12 +662,19 @@ def flush_install_events() -> bool:
             for ack in (acks or [])
             if isinstance(ack, dict) and ack.get("eventId")
         }
-        # A response that acknowledges nothing we sent would loop forever.
-        if not acked:
-            print("⚠️ OTA server acknowledged no install events; keeping the queue.")
-            break
-
+        # The loop only terminates by draining the queue, so it has to be the
+        # queue that is checked. A response can be non-empty and still acknowledge
+        # nothing we sent — ids from another node, or from a batch already
+        # dropped — and testing the response instead reposts the same batch
+        # forever.
+        before = len(remaining)
         remaining = [e for e in remaining if e.get("eventId") not in acked]
+        if len(remaining) == before:
+            print(
+                "⚠️ OTA server acknowledged none of the install events in this "
+                "batch; keeping the queue."
+            )
+            break
 
     dropped = len(remaining) - _MAX_BUFFERED_INSTALL_EVENTS
     if dropped > 0:
@@ -681,6 +713,24 @@ def clear_install_session() -> None:
         _install_event_state_path().write_text(json.dumps(state), encoding="utf-8")
     except OSError:
         pass
+
+
+def archive_is_pinned(
+    archive_name: Optional[str] = None, archive_version: Optional[str] = None
+) -> bool:
+    """Whether this install targets one deliberately chosen archive.
+
+    A pin is a decision someone made about this machine, so nothing may quietly
+    substitute another archive, another tag, or GitHub releases for it. It can
+    come from the command line, or per-node from `RAISIN_ARCHIVE_NAME` — an
+    operator who exports that on a robot has pinned that robot.
+
+    Both the core and `install_command` have to agree on what counts, which is
+    why they ask here instead of each deciding for themselves.
+    """
+    return bool(
+        archive_name or archive_version or os.environ.get("RAISIN_ARCHIVE_NAME")
+    )
 
 
 def get_archive_name(build_type: str, archive_name: Optional[str] = None) -> str:
@@ -1479,6 +1529,15 @@ class ContentHashMismatch(Exception):
     """Downloaded bytes did not match the digest the server advertised."""
 
 
+class OtaInstallHalted(Exception):
+    """The OTA server told this node to stop installing.
+
+    Raised rather than returned so no caller can mistake it for "no archive
+    available" and go looking somewhere else. A halt is an instruction; an
+    empty result is an absence, and the two must not share a representation.
+    """
+
+
 # Error codes from the server's install-event contract
 # (docs/ota-install-event-contract.md). The server treats these as data and
 # never branches on them — classification is the client's job, because the
@@ -1663,6 +1722,20 @@ def _attempt_download(
     with requests.get(
         url, headers=request_headers, params=params, stream=True, timeout=timeout
     ) as resp:
+        # 416 answers a Range we should not have asked for: the partial is
+        # already the whole object — a crash between the digest check and the
+        # rename leaves exactly that — or longer than the server's copy. It is
+        # our request that was wrong, not the server that is unwell, so it
+        # classifies as `unknown` and is never retried. Start over now rather
+        # than spending an attempt, or the package fails identically on every
+        # run until the partial ages out.
+        if resp.status_code == 416 and existing:
+            _discard_part(part_path)
+            # `existing` is 0 on the way back in, so no Range is sent and this
+            # branch cannot be taken again.
+            return _attempt_download(
+                url, part_path, download_path, headers, params, timeout
+            )
         resp.raise_for_status()
 
         # A 200 in response to a Range request means the object changed and the
@@ -2376,7 +2449,7 @@ def download_all_from_archive(
     # An explicit name or version from the caller is a deliberate pin and
     # outranks whatever the fleet has assigned. Only ask the server what to run
     # when the caller expressed no preference.
-    caller_pinned_archive = bool(archive_name) or bool(archive_version)
+    caller_pinned_archive = archive_is_pinned(archive_name, archive_version)
     archive_name = get_archive_name(build_type, archive_name)
 
     desired_manifest = None
@@ -2385,7 +2458,7 @@ def download_all_from_archive(
             _resolve_desired_state(platform_str)
         )
         if halted:
-            return {}
+            raise OtaInstallHalted("the OTA server has halted installs for this node")
         if desired_name and desired_version:
             archive_name, archive_version = desired_name, desired_version
 
@@ -2419,7 +2492,19 @@ def download_all_from_archive(
     if not archive_id:
         return {}
 
-    print(f"📦 Using archive: {archive_name} v{actual_version or 'latest'}")
+    # The version names the directory this install commits into, and the
+    # generation pattern needs a non-empty one. `None` produces a directory
+    # called `0002-None` that `commit_version` can never resolve; an empty
+    # string produces `0002-`, which the pattern cannot see at all, so the next
+    # run stages into the same name. Neither can be committed or rolled back to.
+    if not actual_version:
+        print(
+            f"⚠️ Archive '{archive_name}' came back without a version; "
+            f"refusing to install an archive that cannot be named."
+        )
+        return {}
+
+    print(f"📦 Using archive: {archive_name} v{actual_version}")
     install_session_id = get_install_session_id()
     event_context = {
         "archive_id": archive_id,
@@ -2525,7 +2610,26 @@ def download_all_from_archive(
         )
         return {}
 
-    install_tree.commit_version(release, actual_version, session=install_session_id)
+    # Moving the symlink is what makes an install real. If it did not move,
+    # nothing was installed — and the health check below would read the tree
+    # that is still live and pass, so silence here reports the previous
+    # version's packages as a successful install of this one.
+    committed = install_tree.commit_version(
+        release, actual_version, session=install_session_id
+    )
+    if committed is None:
+        print(
+            f"⚠️ Could not switch release/install to '{archive_name}' "
+            f"v{actual_version}; the previous version keeps running."
+        )
+        install_tree.discard_staging(release, actual_version)
+        note_install_failure(
+            "unpack",
+            ERROR_UNKNOWN,
+            f"commit failed for {archive_name} v{actual_version}",
+        )
+        return {}
+
     print(f"🔀 Switched release/install to {archive_name} v{actual_version}.")
 
     broken = _unusable_packages(install_base_path, requested, build_type)

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -16,6 +16,7 @@ import os
 import re
 import hashlib
 import shutil
+import stat
 import struct
 import subprocess
 import tempfile
@@ -75,6 +76,9 @@ _ROBOT_NODE_KEY_ENV = "RAISIN_ROBOT_NODE_KEY"
 _ROBOT_CONFIG_FILES = ("configuration_setting.yaml", "secrets.yaml")
 _robot_auth_warning_keys = set()
 
+# Caches parsed local config by path and file stat metadata.
+_local_config_cache = {}
+
 # Client identity attached to robot OTA audit/history records.
 DEFAULT_CLIENT_VERSION = "raisin-cli"
 
@@ -128,17 +132,34 @@ def _normalize_optional_string(value) -> Optional[str]:
 
 
 def _load_local_config() -> dict:
-    """Best-effort read of local configuration without enforcing full config validity."""
+    """Best-effort read of local configuration without enforcing full config validity.
+
+    Cached on file stat metadata: robot auth headers are rebuilt for every
+    package download, and each rebuild resolves both the API key and the node
+    key, so an uncached read re-parses the YAML twice per package.
+    """
     script_dir_path = Path(g.script_directory)
     for filename in _ROBOT_CONFIG_FILES:
         config_path = script_dir_path / filename
-        if not config_path.is_file():
+        try:
+            stat_result = config_path.stat()
+        except OSError:
             continue
+        if not stat.S_ISREG(stat_result.st_mode):
+            continue
+
+        cache_token = (stat_result.st_mtime_ns, stat_result.st_size)
+        cached = _local_config_cache.get(config_path)
+        if cached and cached[0] == cache_token:
+            return cached[1]
+
         try:
             config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
         except (OSError, yaml.YAMLError):
             return {}
-        return config if isinstance(config, dict) else {}
+        config = config if isinstance(config, dict) else {}
+        _local_config_cache[config_path] = (cache_token, config)
+        return config
     return {}
 
 
@@ -217,41 +238,56 @@ def _cache_robot_api_key(key_path: Path, api_key: Optional[str]) -> None:
     except OSError:
         _robot_api_key_cache.pop(key_path, None)
         return
-    _robot_api_key_cache[key_path] = (_api_key_cache_token(stat_result), api_key)
+    _robot_api_key_cache[key_path] = (
+        _api_key_cache_token(stat_result),
+        api_key,
+        False,
+    )
 
 
-def _read_robot_api_key_file(key_path: Path) -> Optional[str]:
+def _read_robot_api_key_file_detailed(key_path: Path) -> tuple:
+    """Read a key file, reporting whether a failure was already explained.
+
+    Returns (key, explained). `explained` is True when the reason the key is
+    unusable has already been printed — either by this call or by the earlier
+    call that cached the result — so callers do not stack a second, vaguer
+    warning on top of a specific one.
+    """
     try:
         stat_result = key_path.stat()
     except FileNotFoundError:
         _robot_api_key_cache.pop(key_path, None)
-        return None
+        return (None, False)
     except OSError as e:
         print(f"⚠️ Failed to read robot API key file '{key_path}': {e}")
-        return None
+        return (None, True)
 
     cache_token = _api_key_cache_token(stat_result)
     cached = _robot_api_key_cache.get(key_path)
     if cached and cached[0] == cache_token:
-        return cached[1]
+        return (cached[1], cached[2])
 
     if os.name == "posix" and (stat_result.st_mode & 0o077):
         print(
             "⚠️ Ignoring robot API key file with insecure permissions: "
             f"{key_path} (run: chmod 600 {key_path})"
         )
-        _robot_api_key_cache[key_path] = (cache_token, None)
-        return None
+        _robot_api_key_cache[key_path] = (cache_token, None, True)
+        return (None, True)
 
     try:
         key = key_path.read_text(encoding="utf-8").strip()
     except OSError as e:
         print(f"⚠️ Failed to read robot API key file '{key_path}': {e}")
-        return None
+        return (None, True)
 
     cached_key = key or None
-    _robot_api_key_cache[key_path] = (cache_token, cached_key)
-    return cached_key
+    _robot_api_key_cache[key_path] = (cache_token, cached_key, False)
+    return (cached_key, False)
+
+
+def _read_robot_api_key_file(key_path: Path) -> Optional[str]:
+    return _read_robot_api_key_file_detailed(key_path)[0]
 
 
 def get_robot_api_key() -> Optional[str]:
@@ -272,7 +308,20 @@ def get_robot_api_key() -> Optional[str]:
 
     env_key_file = os.environ.get(_ROBOT_API_KEY_FILE_ENV, "").strip()
     if env_key_file:
-        return _read_robot_api_key_file(Path(env_key_file).expanduser())
+        # An explicitly pinned path is a deliberate choice. Do not fall through
+        # to the config file or the default path when it does not resolve —
+        # say so instead, or the robot quietly downloads as an anonymous client.
+        key, explained = _read_robot_api_key_file_detailed(
+            Path(env_key_file).expanduser()
+        )
+        if not key and not explained:
+            _warn_robot_auth_config_once(
+                f"unreadable_key_file:{env_key_file}",
+                f"⚠️ {_ROBOT_API_KEY_FILE_ENV} points at '{env_key_file}' but no "
+                "robot API key could be read from it. Using legacy OTA "
+                "authentication instead.",
+            )
+        return key
 
     config_key = _get_local_config_value(
         (
@@ -1079,6 +1128,97 @@ def _robot_auth_headers(install_session_id: Optional[str] = None) -> Optional[di
     }
 
 
+def fetch_robot_desired_state() -> Optional[dict]:
+    """Ask the OTA server what this robot node is supposed to be running.
+
+    Returns the resolved desired-state document, or None when robot auth is
+    not configured or the server cannot answer. Never raises: desired state is
+    an optional refinement of the caller's own archive selection.
+    """
+    headers = _robot_auth_headers()
+    if not headers:
+        return None
+
+    base = get_ota_endpoint().rstrip("/")
+    try:
+        resp = requests.get(
+            f"{base}/robots/me/desired-state", headers=headers, timeout=10
+        )
+        if resp.status_code == 404:
+            # Either the node is not registered or the server predates the
+            # endpoint. Both mean "no opinion", not "install nothing".
+            return None
+        resp.raise_for_status()
+        state = _unwrap_response(resp.json())
+        return state if isinstance(state, dict) else None
+    except (requests.RequestException, ValueError) as e:
+        print(f"⚠️ Failed to fetch OTA desired state: {e}")
+        return None
+
+
+def _resolve_desired_state(platform_str: str) -> tuple:
+    """Fold the server's desired state into an archive selection.
+
+    Returns (halted, archive_name, archive_version). Name and version are None
+    whenever the server has no usable opinion, leaving the caller's own
+    selection untouched.
+    """
+    state = fetch_robot_desired_state()
+    if not state:
+        return (False, None, None)
+
+    if state.get("halt"):
+        sources = ", ".join(state.get("haltSources") or []) or "an unknown scope"
+        print(f"⛔ OTA installs are halted for this node by: {sources}.")
+        return (True, None, None)
+
+    target = state.get("target")
+    if not isinstance(target, dict):
+        if state.get("reason") == "target_unresolved":
+            detail = state.get("unresolvedDetail") or "no detail given"
+            print(
+                "⚠️ The OTA server has an archive assigned to this node but "
+                f"could not resolve it: {detail}."
+            )
+        return (False, None, None)
+
+    target_platform = _normalize_optional_string(target.get("platform"))
+    if target_platform and target_platform != platform_str:
+        print(
+            f"⚠️ OTA desired state targets '{target_platform}' but this node "
+            f"is '{platform_str}'. Ignoring it."
+        )
+        return (False, None, None)
+
+    name = _normalize_optional_string(target.get("name"))
+    version = _normalize_optional_string(target.get("version"))
+    if not name or not version:
+        return (False, None, None)
+
+    print(
+        f"🛰️  OTA desired state ({state.get('reason')}): "
+        f"{name} v{version} on {target_platform or platform_str}"
+    )
+    return (False, name, version)
+
+
+def _expected_content_hash(response_headers) -> Optional[str]:
+    """Extract the sha256 the server claims for a download body.
+
+    The by-key endpoints send the blob digest as `X-Content-Hash` and reuse it
+    as the ETag, so fall back to the ETag when the explicit header is absent.
+    """
+    for header in ("X-Content-Hash", "ETag"):
+        raw = response_headers.get(header)
+        if not isinstance(raw, str):
+            continue
+        candidate = raw.strip().removeprefix("W/").strip('"')
+        candidate = candidate.removeprefix("sha256:").lower()
+        if re.fullmatch(r"[a-f0-9]{64}", candidate):
+            return candidate
+    return None
+
+
 def _stream_robot_package_download(
     package_id: str,
     package_name: str,
@@ -1103,9 +1243,26 @@ def _stream_robot_package_download(
             url, headers=headers, params=params, stream=True, timeout=60
         ) as resp:
             resp.raise_for_status()
+            digest = hashlib.sha256()
             with open(download_path, "wb") as f:
                 for chunk in resp.iter_content(chunk_size=8192):
+                    digest.update(chunk)
                     f.write(chunk)
+            expected = _expected_content_hash(resp.headers)
+
+        # Nobody is watching an unattended robot install, so a truncated or
+        # corrupted body has to fail here rather than surface later as a
+        # confusing "not a zip file" during extraction.
+        if expected and digest.hexdigest() != expected:
+            raise OSError(
+                f"content hash mismatch (expected {expected}, "
+                f"got {digest.hexdigest()})"
+            )
+        if not expected:
+            print(
+                f"⚠️ OTA server sent no content hash for '{package_name}'; "
+                "download integrity was not verified."
+            )
         return True
     except (requests.RequestException, OSError) as e:
         if download_path.exists():
@@ -1245,14 +1402,56 @@ def _build_archive_install_metadata(
     }
 
 
-def _snapshot_package_from_metadata(metadata: dict) -> Optional[dict]:
-    """Convert one ota-install.json document into a snapshot package item."""
+def manifest_hashes_by_package_id(packages: Optional[list]) -> dict:
+    """Map packageId → manifestHash from an archive manifest package list."""
+    hashes_by_id = {}
+    for pkg in packages or []:
+        if not isinstance(pkg, dict):
+            continue
+        pkg_id = str(pkg.get("packageId") or pkg.get("id") or "").strip()
+        manifest_hash = str(pkg.get("manifestHash") or "").strip()
+        if pkg_id and manifest_hash:
+            hashes_by_id[pkg_id] = manifest_hash
+    return hashes_by_id
+
+
+def _snapshot_package_from_metadata(
+    metadata: dict, manifest_hashes: Optional[dict] = None
+) -> Optional[dict]:
+    """Convert one ota-install.json document into a snapshot package item.
+
+    `manifestHash` is required by the server for archive packages and must
+    match the archive manifest exactly. Installs recorded before the field was
+    written lack it, so recover it from the archive manifest rather than
+    dropping the package: the server clears and replaces the node's whole
+    package set on every snapshot, so an omission is recorded as "not
+    installed" rather than "unknown".
+    """
     package_id = str(metadata.get("packageId") or "").strip()
     package_name = str(metadata.get("packageName") or "").strip()
     version = str(metadata.get("packageVersion") or "").strip().lstrip("vV")
     manifest_hash = str(metadata.get("manifestHash") or "").strip()
-    if not package_id or not package_name or not version or not manifest_hash:
+    if not package_id or not package_name or not version:
         return None
+
+    if not manifest_hash:
+        manifest_hash = (manifest_hashes or {}).get(package_id, "")
+        if manifest_hash:
+            print(
+                f"ℹ️  '{package_name}' has no recorded manifest hash; "
+                "recovered it from the archive manifest for snapshot reporting."
+            )
+
+    if not manifest_hash:
+        # Reporting it as a custom package is not an option: the server rejects
+        # customPackages entries whose packageId is in the archive manifest.
+        print(
+            f"⚠️ Excluding '{package_name}=={version}' from the OTA software "
+            "snapshot: no manifest hash on disk or in the archive manifest. "
+            "The server will not show it as installed on this node."
+        )
+        return None
+
     return {
         "packageId": package_id,
         "packageName": package_name,
@@ -1266,6 +1465,7 @@ def _collect_archive_snapshot_packages(
     archive_id: str,
     platform_str: str,
     build_type: str,
+    manifest_hashes: Optional[dict] = None,
 ) -> list:
     """Collect currently installed package metadata for an archive."""
     metadata_pattern = f"*/*/*/*/{build_type}/{_INSTALL_METADATA_FILE}"
@@ -1287,7 +1487,7 @@ def _collect_archive_snapshot_packages(
         if metadata.get("buildType") != build_type:
             continue
 
-        package = _snapshot_package_from_metadata(metadata)
+        package = _snapshot_package_from_metadata(metadata, manifest_hashes)
         if package:
             packages_by_id[package["packageId"]] = package
 
@@ -1349,8 +1549,15 @@ def _queue_snapshot_report(
     platform_str: str,
     build_type: str,
     install_session_id: str,
+    manifest_hashes: Optional[dict] = None,
 ) -> None:
     key = (archive_id, platform_str, build_type, install_session_id)
+    pending = _pending_snapshot_reports.get(key)
+    # Successive single-package installs each contribute the slice of the
+    # archive manifest they resolved; keep the union so the deferred report can
+    # still backfill hashes for packages installed earlier in this process.
+    merged_hashes = dict(pending["manifest_hashes"]) if pending else {}
+    merged_hashes.update(manifest_hashes or {})
     _pending_snapshot_reports[key] = {
         "install_base_path": install_base_path,
         "archive_id": archive_id,
@@ -1359,6 +1566,7 @@ def _queue_snapshot_report(
         "platform_str": platform_str,
         "build_type": build_type,
         "install_session_id": install_session_id,
+        "manifest_hashes": merged_hashes,
     }
 
 
@@ -1377,12 +1585,14 @@ def _report_snapshot_from_install_metadata(
     platform_str: str,
     build_type: str,
     install_session_id: str,
+    manifest_hashes: Optional[dict] = None,
 ) -> bool:
     packages = _collect_archive_snapshot_packages(
         install_base_path=install_base_path,
         archive_id=archive_id,
         platform_str=platform_str,
         build_type=build_type,
+        manifest_hashes=manifest_hashes,
     )
     if not packages:
         return False
@@ -1556,6 +1766,7 @@ def download_package(
             platform_str=platform_str,
             build_type=build_type,
             install_session_id=install_session_id,
+            manifest_hashes=manifest_hashes_by_package_id(packages),
         )
     return result
 
@@ -1589,7 +1800,19 @@ def download_all_from_archive(
         for successfully downloaded packages. Empty dict on complete failure.
     """
     platform_str = f"{g.os_type}-{g.os_version}-{g.architecture}"
+
+    # An explicit name or version from the caller is a deliberate pin and
+    # outranks whatever the fleet has assigned. Only ask the server what to run
+    # when the caller expressed no preference.
+    caller_pinned_archive = bool(archive_name) or bool(archive_version)
     archive_name = get_archive_name(build_type, archive_name)
+
+    if not caller_pinned_archive:
+        halted, desired_name, desired_version = _resolve_desired_state(platform_str)
+        if halted:
+            return {}
+        if desired_name and desired_version:
+            archive_name, archive_version = desired_name, desired_version
 
     # Selection priority: archive_version > tag > legacy latest.
     if archive_version:
@@ -1696,6 +1919,7 @@ def download_all_from_archive(
             platform_str=platform_str,
             build_type=build_type,
             install_session_id=install_session_id,
+            manifest_hashes=manifest_hashes_by_package_id(packages),
         )
 
     return results

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -29,8 +29,6 @@ import zipfile
 import requests
 import yaml
 from packaging.specifiers import SpecifierSet, InvalidSpecifier
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa, padding
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -750,6 +748,25 @@ def _clear_cached_token():
 # ============================================================================
 
 
+def _sign_nonce(nonce: str, key_path: Path) -> str:
+    """Sign a nonce with an SSH private key.
+
+    Imported lazily: signing is the only thing here that needs
+    `cryptography`, and it belongs to the user-authenticated path. A robot
+    authenticates with its own credential and never reaches this, so it
+    should not have to install a native extension to run.
+    """
+    try:
+        from . import ota_ssh
+    except ImportError as e:  # pragma: no cover - depends on the install extra
+        raise RuntimeError(
+            "SSH authentication needs the 'cryptography' package. "
+            "Install the ssh extra, or use a robot credential instead."
+        ) from e
+
+    return ota_ssh.sign_nonce(nonce, key_path)
+
+
 def _get_ssh_fingerprint(key_path: Path) -> str:
     """Run ssh-keygen -lf <key.pub> and return hex-encoded SHA256 fingerprint.
 
@@ -769,58 +786,6 @@ def _get_ssh_fingerprint(key_path: Path) -> str:
     # Convert base64 → raw bytes → hex
     padded = sha256_b64 + "=" * (-len(sha256_b64) % 4)
     return base64.b64decode(padded).hex()
-
-
-def _sign_nonce(nonce: str, key_path: Path) -> str:
-    """Sign nonce with SSH private key (supports ed25519, RSA, ECDSA).
-
-    Loads the SSH private key via the ``cryptography`` library and signs
-    the nonce bytes directly. Returns the signature as base64-encoded SSH
-    wire format (length-prefixed algorithm name + length-prefixed raw signature).
-
-    Supported key types:
-        - Ed25519 (ssh-ed25519)
-        - RSA (ssh-rsa) - uses SHA-256 with PKCS1v15 padding
-        - ECDSA (ecdsa-sha2-nistp256, nistp384, nistp521)
-    """
-    with open(key_path, "rb") as f:
-        private_key = serialization.load_ssh_private_key(f.read(), password=None)
-
-    data = bytes.fromhex(nonce)
-
-    # Sign based on key type
-    if isinstance(private_key, ed25519.Ed25519PrivateKey):
-        algo = b"ssh-ed25519"
-        raw_sig = private_key.sign(data)
-
-    elif isinstance(private_key, rsa.RSAPrivateKey):
-        algo = b"rsa-sha2-256"
-        raw_sig = private_key.sign(data, padding.PKCS1v15(), hashes.SHA256())
-
-    elif isinstance(private_key, ec.EllipticCurvePrivateKey):
-        # Determine curve and algorithm name
-        curve_name = private_key.curve.name
-        if curve_name == "secp256r1":
-            algo = b"ecdsa-sha2-nistp256"
-            hash_algo = hashes.SHA256()
-        elif curve_name == "secp384r1":
-            algo = b"ecdsa-sha2-nistp384"
-            hash_algo = hashes.SHA384()
-        elif curve_name == "secp521r1":
-            algo = b"ecdsa-sha2-nistp521"
-            hash_algo = hashes.SHA512()
-        else:
-            raise ValueError(f"Unsupported ECDSA curve: {curve_name}")
-        raw_sig = private_key.sign(data, ec.ECDSA(hash_algo))
-
-    else:
-        raise ValueError(f"Unsupported SSH key type: {type(private_key).__name__}")
-
-    # Build SSH wire format: length-prefixed algo + length-prefixed signature
-    sig_wire = (
-        struct.pack(">I", len(algo)) + algo + struct.pack(">I", len(raw_sig)) + raw_sig
-    )
-    return base64.b64encode(sig_wire).decode()
 
 
 def authenticate() -> Optional[str]:

--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -28,14 +28,14 @@ import zipfile
 
 import requests
 import yaml
+from packaging.specifiers import SpecifierSet, InvalidSpecifier
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa, padding
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from commands import globals as g
 from commands import install_tree
-from commands.utils import parse_version_specifier
 
 # Module-level cached auth token (lives for the CLI session)
 _cached_token = None
@@ -108,6 +108,92 @@ DEFAULT_CLIENT_VERSION = "raisin-cli"
 
 
 # ============================================================================
+# Runtime context
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class OtaContext:
+    """Where this process works and what platform it is working for.
+
+    The CLI fills these from its own startup; an agent supplies them directly.
+    Reading them from a CLI module would tie the core to a process that only
+    exists in one of its two callers.
+    """
+
+    workspace: Path
+    os_type: str
+    os_version: str
+    architecture: str
+
+    @property
+    def platform(self) -> str:
+        """Platform string as the OTA server names it, e.g. ubuntu-24.04-arm64."""
+        return f"{self.os_type}-{self.os_version}-{self.architecture}"
+
+    def package_dir(self, base: Path, package: str, build_type: str) -> Path:
+        """Where one package's files live under an install tree."""
+        return (
+            Path(base)
+            / package
+            / self.os_type
+            / self.os_version
+            / self.architecture
+            / build_type
+        )
+
+
+_context = None
+
+
+def configure(context: OtaContext) -> None:
+    """Point the core at a workspace and platform. Call once at startup."""
+    global _context
+    _context = context
+
+
+def _ctx() -> OtaContext:
+    if _context is None:
+        raise RuntimeError(
+            "OTA core is not configured; call ota_client.configure(OtaContext(...)) "
+            "before using it."
+        )
+    return _context
+
+
+def parse_version_specifier(spec_str):
+    """Parse a version specifier string into a SpecifierSet.
+
+    Kept here rather than imported: the CLI's utils module pulls in process
+    globals at import time, and this function needs none of them.
+
+        ""            -> >=0.0.0 (any version)
+        ">=1.0.0"     -> standard specifier
+        ">=1.0,<2.0"  -> compound specifier
+        "1.0.0"       -> treated as ==1.0.0
+
+    Returns a SpecifierSet, or None when the string cannot be parsed.
+    """
+    try:
+        spec_str = (spec_str or "").strip()
+        if not spec_str:
+            return SpecifierSet(">=0.0.0")
+
+        specifiers = re.findall(r"[<>=!~]+[\d.]+", spec_str)
+        if specifiers:
+            formatted = ", ".join(specifiers)
+            formatted = formatted.replace(">, =", ">=").replace("< =", "<=")
+            return SpecifierSet(formatted)
+
+        if re.match(r"^[\d.]+$", spec_str):
+            return SpecifierSet(f"=={spec_str}")
+
+        return None
+    except InvalidSpecifier:
+        return None
+
+
+# ============================================================================
 # Configuration
 # ============================================================================
 
@@ -162,7 +248,7 @@ def _load_local_config() -> dict:
     package download, and each rebuild resolves both the API key and the node
     key, so an uncached read re-parses the YAML twice per package.
     """
-    script_dir_path = Path(g.script_directory)
+    script_dir_path = _ctx().workspace
     for filename in _ROBOT_CONFIG_FILES:
         config_path = script_dir_path / filename
         try:
@@ -397,7 +483,7 @@ def get_client_version() -> str:
 
 
 def _install_session_path() -> Path:
-    return Path(g.script_directory) / "install" / _INSTALL_SESSION_FILE
+    return _ctx().workspace / "install" / _INSTALL_SESSION_FILE
 
 
 def _read_install_session() -> Optional[str]:
@@ -459,14 +545,7 @@ def _unusable_packages(install_base_path: Path, requested, build_type: str) -> l
     """
     broken = []
     for name in sorted(requested):
-        package_dir = (
-            install_base_path
-            / name
-            / g.os_type
-            / g.os_version
-            / g.architecture
-            / build_type
-        )
+        package_dir = _ctx().package_dir(install_base_path, name, build_type)
         try:
             if not package_dir.is_dir() or not any(package_dir.iterdir()):
                 broken.append(name)
@@ -496,11 +575,11 @@ def _utc_now_iso() -> str:
 
 
 def _install_event_queue_path() -> Path:
-    return Path(g.script_directory) / "install" / _INSTALL_EVENT_QUEUE_FILE
+    return _ctx().workspace / "install" / _INSTALL_EVENT_QUEUE_FILE
 
 
 def _install_event_state_path() -> Path:
-    return Path(g.script_directory) / "install" / _INSTALL_EVENT_STATE_FILE
+    return _ctx().workspace / "install" / _INSTALL_EVENT_STATE_FILE
 
 
 def _read_install_event_queue() -> list:
@@ -795,7 +874,7 @@ def get_archive_name(build_type: str, archive_name: Optional[str] = None) -> str
 
 def _get_token_cache_path() -> Path:
     """Path to the persistent token cache file."""
-    return Path(g.script_directory) / _TOKEN_CACHE_FILE
+    return _ctx().workspace / _TOKEN_CACHE_FILE
 
 
 def _is_jwt_expired(token: str) -> bool:
@@ -1129,7 +1208,7 @@ def upload_package(
     try:
         # 1. Compute SHA256
         sha256 = _compute_sha256(archive_path)
-        platform_str = f"{g.os_type}-{g.os_version}-{g.architecture}"
+        platform_str = _ctx().platform
 
         # 2. Check if blob already exists (deduplication)
         resp = requests.get(
@@ -2327,7 +2406,7 @@ def download_package(
     """
     from packaging.version import parse as parse_version, InvalidVersion
 
-    platform_str = f"{g.os_type}-{g.os_version}-{g.architecture}"
+    platform_str = _ctx().platform
     archive_name = get_archive_name(build_type, archive_name)
 
     # Selection priority mirrors download_all_from_archive:
@@ -2388,18 +2467,9 @@ def download_package(
     tag = best_pkg.get("tagName") or best_pkg.get("version", "")
     version = tag.lstrip("vV") if tag else "0.0.0"
 
-    install_dir = (
-        install_base_path
-        / package_name
-        / g.os_type
-        / g.os_version
-        / g.architecture
-        / build_type
-    )
+    install_dir = _ctx().package_dir(install_base_path, package_name, build_type)
 
-    download_file = (
-        Path(g.script_directory) / "install" / f"{package_name}-ota-{version}.zip"
-    )
+    download_file = _ctx().workspace / "install" / f"{package_name}-ota-{version}.zip"
 
     install_session_id = get_install_session_id()
 
@@ -2505,7 +2575,7 @@ def download_all_from_archive(
         dict mapping package_name to {'version': str, 'dependencies': list}
         for successfully downloaded packages. Empty dict on complete failure.
     """
-    platform_str = f"{g.os_type}-{g.os_version}-{g.architecture}"
+    platform_str = _ctx().platform
 
     release = install_tree.release_for(install_base_path)
     repaired = install_tree.ensure_tree(release)
@@ -2596,13 +2666,9 @@ def download_all_from_archive(
 
         # _extract_and_read_deps removes this directory before unpacking, which
         # is what breaks the hardlink shared with the previous version.
-        install_dir = (
-            staging / name / g.os_type / g.os_version / g.architecture / build_type
-        )
+        install_dir = _ctx().package_dir(staging, name, build_type)
 
-        download_file = (
-            Path(g.script_directory) / "install" / f"{name}-ota-{version}.zip"
-        )
+        download_file = _ctx().workspace / "install" / f"{name}-ota-{version}.zip"
 
         print(f"⬇️  Downloading '{name}' v{version} from OTA server...")
         download_ok, _download_error = _download_package_blob(
@@ -2789,7 +2855,7 @@ def download_package_at_timestamp(
     if not ctx:
         return None
     base, headers = ctx
-    platform_str = f"{g.os_type}-{g.os_version}-{g.architecture}"
+    platform_str = _ctx().platform
 
     try:
         # Fetch manifest at timestamp
@@ -2818,17 +2884,10 @@ def download_package_at_timestamp(
             print(f"⚠️ Manifest for '{package_name}' has no blob hash")
             return None
 
-        install_dir = (
-            install_base_path
-            / package_name
-            / g.os_type
-            / g.os_version
-            / g.architecture
-            / build_type
-        )
+        install_dir = _ctx().package_dir(install_base_path, package_name, build_type)
 
         download_file = (
-            Path(g.script_directory) / "install" / f"{package_name}-ota-{version}.zip"
+            _ctx().workspace / "install" / f"{package_name}-ota-{version}.zip"
         )
 
         print(f"⬇️  Downloading '{package_name}' v{version} (at {timestamp})...")

--- a/commands/ota_ssh.py
+++ b/commands/ota_ssh.py
@@ -1,0 +1,65 @@
+"""SSH nonce signing for the user-authenticated OTA path.
+
+Split out because it is the only place the core needs `cryptography`, a
+native extension. A robot authenticates with its own credential and never
+calls this, so it should not have to build or patch one.
+"""
+
+import base64
+import struct
+from pathlib import Path
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, padding, rsa
+
+
+def sign_nonce(nonce: str, key_path: Path) -> str:
+    """Sign nonce with SSH private key (supports ed25519, RSA, ECDSA).
+
+    Loads the SSH private key via the ``cryptography`` library and signs
+    the nonce bytes directly. Returns the signature as base64-encoded SSH
+    wire format (length-prefixed algorithm name + length-prefixed raw signature).
+
+    Supported key types:
+        - Ed25519 (ssh-ed25519)
+        - RSA (ssh-rsa) - uses SHA-256 with PKCS1v15 padding
+        - ECDSA (ecdsa-sha2-nistp256, nistp384, nistp521)
+    """
+    with open(key_path, "rb") as f:
+        private_key = serialization.load_ssh_private_key(f.read(), password=None)
+
+    data = bytes.fromhex(nonce)
+
+    # Sign based on key type
+    if isinstance(private_key, ed25519.Ed25519PrivateKey):
+        algo = b"ssh-ed25519"
+        raw_sig = private_key.sign(data)
+
+    elif isinstance(private_key, rsa.RSAPrivateKey):
+        algo = b"rsa-sha2-256"
+        raw_sig = private_key.sign(data, padding.PKCS1v15(), hashes.SHA256())
+
+    elif isinstance(private_key, ec.EllipticCurvePrivateKey):
+        # Determine curve and algorithm name
+        curve_name = private_key.curve.name
+        if curve_name == "secp256r1":
+            algo = b"ecdsa-sha2-nistp256"
+            hash_algo = hashes.SHA256()
+        elif curve_name == "secp384r1":
+            algo = b"ecdsa-sha2-nistp384"
+            hash_algo = hashes.SHA384()
+        elif curve_name == "secp521r1":
+            algo = b"ecdsa-sha2-nistp521"
+            hash_algo = hashes.SHA512()
+        else:
+            raise ValueError(f"Unsupported ECDSA curve: {curve_name}")
+        raw_sig = private_key.sign(data, ec.ECDSA(hash_algo))
+
+    else:
+        raise ValueError(f"Unsupported SSH key type: {type(private_key).__name__}")
+
+    # Build SSH wire format: length-prefixed algo + length-prefixed signature
+    sig_wire = (
+        struct.pack(">I", len(algo)) + algo + struct.pack(">I", len(raw_sig)) + raw_sig
+    )
+    return base64.b64encode(sig_wire).decode()

--- a/commands/robot_credentials.py
+++ b/commands/robot_credentials.py
@@ -1,0 +1,310 @@
+"""Resolve this machine's robot credential for the OTA core.
+
+Where a credential lives is a property of the machine, not of the OTA
+protocol: a developer has a shell and a HOME, a robot has a service account
+and a provisioned key file. The core takes an identity and asks no questions,
+so this module answers them and hands the result to `ota_client.configure`.
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from commands import globals as g
+from commands.ota_client import RobotIdentity
+
+# Robot API key configuration. The key file is intentionally outside the repo.
+_ROBOT_API_KEY_FILE = "robot-api-key"  # pragma: allowlist secret
+_ROBOT_API_KEY_ENV = "RAISIN_ROBOT_API_KEY"  # pragma: allowlist secret
+_ROBOT_API_KEY_FILE_ENV = "RAISIN_ROBOT_API_KEY_FILE"  # pragma: allowlist secret
+_ROBOT_NODE_ENV = "RAISIN_ROBOT_NODE"
+_ROBOT_NODE_KEY_ENV = "RAISIN_ROBOT_NODE_KEY"
+_ROBOT_CONFIG_FILES = ("configuration_setting.yaml", "secrets.yaml")
+
+DEFAULT_CLIENT_VERSION = "raisin-cli"
+
+_robot_api_key_cache = {}
+_local_config_cache = {}
+_robot_auth_warning_keys = set()
+
+
+def _load_local_config() -> dict:
+    """Best-effort read of local configuration without enforcing full config validity.
+
+    Cached on file stat metadata: robot auth headers are rebuilt for every
+    package download, and each rebuild resolves both the API key and the node
+    key, so an uncached read re-parses the YAML twice per package.
+    """
+    script_dir_path = Path(g.script_directory)
+    for filename in _ROBOT_CONFIG_FILES:
+        config_path = script_dir_path / filename
+        try:
+            stat_result = config_path.stat()
+        except OSError:
+            continue
+        if not stat.S_ISREG(stat_result.st_mode):
+            continue
+
+        cache_token = (stat_result.st_mtime_ns, stat_result.st_size)
+        cached = _local_config_cache.get(config_path)
+        if cached and cached[0] == cache_token:
+            return cached[1]
+
+        try:
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            return {}
+        config = config if isinstance(config, dict) else {}
+        _local_config_cache[config_path] = (cache_token, config)
+        return config
+    return {}
+
+
+def _get_nested_config_value(config: dict, path: tuple) -> Optional[str]:
+    current = config
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return _normalize_optional_string(current)
+
+
+def _get_local_config_value(paths: tuple) -> Optional[str]:
+    config = _load_local_config()
+    for path in paths:
+        value = _get_nested_config_value(config, path)
+        if value:
+            return value
+    return None
+
+
+def get_robot_api_key_path() -> Path:
+    """Get the local robot API key path.
+
+    Resolution order:
+        1. RAISIN_ROBOT_API_KEY_FILE environment variable
+        2. ~/.config/raisin/robot-api-key
+    """
+    env_path = os.environ.get(_ROBOT_API_KEY_FILE_ENV, "").strip()
+    if env_path:
+        return Path(env_path).expanduser()
+    return Path.home() / ".config" / "raisin" / _ROBOT_API_KEY_FILE
+
+
+def save_robot_api_key(api_key: str, path: Optional[Path] = None) -> Path:
+    """Persist a robot API key with owner-only file permissions."""
+    key = (api_key or "").strip()
+    if not key:
+        raise ValueError("Robot API key cannot be empty")
+
+    target = Path(path).expanduser() if path else get_robot_api_key_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    temp_path = target.with_name(f".{target.name}.tmp")
+    try:
+        fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(key + "\n")
+        temp_path.replace(target)
+    finally:
+        try:
+            if temp_path.exists():
+                temp_path.unlink()
+        except OSError:
+            pass
+
+    try:
+        os.chmod(target, 0o600)
+    except OSError:
+        pass
+    _cache_robot_api_key(target, key)
+    return target
+
+
+def _read_robot_api_key_file_detailed(key_path: Path) -> tuple:
+    """Read a key file, reporting whether a failure was already explained.
+
+    Returns (key, explained). `explained` is True when the reason the key is
+    unusable has already been printed — either by this call or by the earlier
+    call that cached the result — so callers do not stack a second, vaguer
+    warning on top of a specific one.
+    """
+    try:
+        stat_result = key_path.stat()
+    except FileNotFoundError:
+        _robot_api_key_cache.pop(key_path, None)
+        return (None, False)
+    except OSError as e:
+        print(f"⚠️ Failed to read robot API key file '{key_path}': {e}")
+        return (None, True)
+
+    cache_token = _api_key_cache_token(stat_result)
+    cached = _robot_api_key_cache.get(key_path)
+    if cached and cached[0] == cache_token:
+        return (cached[1], cached[2])
+
+    if os.name == "posix" and (stat_result.st_mode & 0o077):
+        print(
+            "⚠️ Ignoring robot API key file with insecure permissions: "
+            f"{key_path} (run: chmod 600 {key_path})"
+        )
+        _robot_api_key_cache[key_path] = (cache_token, None, True)
+        return (None, True)
+
+    try:
+        key = key_path.read_text(encoding="utf-8").strip()
+    except OSError as e:
+        print(f"⚠️ Failed to read robot API key file '{key_path}': {e}")
+        return (None, True)
+
+    cached_key = key or None
+    _robot_api_key_cache[key_path] = (cache_token, cached_key, False)
+    return (cached_key, False)
+
+
+def _read_robot_api_key_file(key_path: Path) -> Optional[str]:
+    return _read_robot_api_key_file_detailed(key_path)[0]
+
+
+def get_robot_api_key() -> Optional[str]:
+    """Read the robot API key from env or the local key file.
+
+    Resolution order:
+        1. RAISIN_ROBOT_API_KEY
+        2. RAISIN_ROBOT_API_KEY_FILE
+        3. configuration_setting.yaml/secrets.yaml robot.api_key
+        4. ~/.config/raisin/robot-api-key
+
+    File-backed keys are ignored on POSIX systems if group/other permissions
+    are enabled.
+    """
+    env_key = os.environ.get(_ROBOT_API_KEY_ENV, "").strip()
+    if env_key:
+        return env_key
+
+    env_key_file = os.environ.get(_ROBOT_API_KEY_FILE_ENV, "").strip()
+    if env_key_file:
+        # An explicitly pinned path is a deliberate choice. Do not fall through
+        # to the config file or the default path when it does not resolve —
+        # say so instead, or the robot quietly downloads as an anonymous client.
+        key, explained = _read_robot_api_key_file_detailed(
+            Path(env_key_file).expanduser()
+        )
+        if not key and not explained:
+            _warn_robot_auth_config_once(
+                f"unreadable_key_file:{env_key_file}",
+                f"⚠️ {_ROBOT_API_KEY_FILE_ENV} points at '{env_key_file}' but no "
+                "robot API key could be read from it. Using legacy OTA "
+                "authentication instead.",
+            )
+        return key
+
+    config_key = _get_local_config_value(
+        (
+            ("robot", "api_key"),
+            ("robot", "apiKey"),
+            ("ota", "robot_api_key"),
+            ("robot_api_key",),
+        )
+    )
+    if config_key:
+        return config_key
+
+    return _read_robot_api_key_file(get_robot_api_key_path())
+
+
+def get_robot_node_key() -> Optional[str]:
+    """Read the robot-local node key required by robot-authenticated endpoints."""
+    for env_name in (_ROBOT_NODE_ENV, _ROBOT_NODE_KEY_ENV):
+        env_value = _normalize_optional_string(os.environ.get(env_name))
+        if env_value:
+            return env_value
+
+    return _get_local_config_value(
+        (
+            ("robot", "node"),
+            ("robot", "node_key"),
+            ("robot", "nodeKey"),
+            ("ota", "robot_node"),
+            ("robot_node",),
+            ("robot_node_key",),
+        )
+    )
+
+
+def _cache_robot_api_key(key_path: Path, api_key: Optional[str]) -> None:
+    try:
+        stat_result = key_path.stat()
+    except OSError:
+        _robot_api_key_cache.pop(key_path, None)
+        return
+    _robot_api_key_cache[key_path] = (
+        _api_key_cache_token(stat_result),
+        api_key,
+        False,
+    )
+
+
+def _api_key_cache_token(stat_result) -> tuple:
+    return (
+        stat_result.st_mtime_ns,
+        stat_result.st_size,
+        stat_result.st_mode & 0o777,
+    )
+
+
+def _warn_robot_auth_config_once(key: str, message: str) -> None:
+    if key in _robot_auth_warning_keys:
+        return
+    _robot_auth_warning_keys.add(key)
+    print(message)
+
+
+def get_client_version() -> str:
+    """Return the OTA client identity used in robot audit/history records."""
+    for env_name in ("RAISIN_OTA_CLIENT_VERSION", "RAISIN_CLIENT_VERSION"):
+        value = os.environ.get(env_name, "").strip()
+        if value:
+            return value
+    return DEFAULT_CLIENT_VERSION
+
+
+def _normalize_optional_string(value) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    if not value or value.lower() in {"none", "null"}:
+        return None
+    return value
+
+
+def resolve_robot_identity() -> Optional[RobotIdentity]:
+    """Build the identity for the core, or None when this machine has none.
+
+    A key without a node key is not a usable identity: the robot endpoints
+    resolve a *node*, so half a credential would fail every request. Say so
+    once and fall back to the user-authenticated route.
+    """
+    api_key = get_robot_api_key()
+    if not api_key:
+        return None
+
+    node_key = get_robot_node_key()
+    if not node_key:
+        _warn_robot_auth_config_once(
+            "missing_robot_node",
+            "⚠️ Robot API key is configured but robot node is missing "
+            "(set RAISIN_ROBOT_NODE or configuration_setting.yaml robot.node). "
+            "Using legacy OTA authentication instead.",
+        )
+        return None
+
+    return RobotIdentity(
+        api_key=api_key, node_key=node_key, client_version=get_client_version()
+    )

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -378,8 +378,9 @@ def init_environment(script_file_path, yes_flag):
         always_yes=yes_flag,
     )
 
-    # The OTA core does not read these globals; hand it the same values.
-    from commands import ota_client
+    # The OTA core does not read these globals, nor does it resolve a
+    # credential; hand it both.
+    from commands import ota_client, robot_credentials
 
     ota_client.configure(
         ota_client.OtaContext(
@@ -387,6 +388,7 @@ def init_environment(script_file_path, yes_flag):
             os_type=os_type,
             os_version=os_version,
             architecture=architecture,
+            robot=robot_credentials.resolve_robot_identity(),
         )
     )
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -378,4 +378,16 @@ def init_environment(script_file_path, yes_flag):
         always_yes=yes_flag,
     )
 
+    # The OTA core does not read these globals; hand it the same values.
+    from commands import ota_client
+
+    ota_client.configure(
+        ota_client.OtaContext(
+            workspace=Path(script_directory),
+            os_type=os_type,
+            os_version=os_version,
+            architecture=architecture,
+        )
+    )
+
     delete_directory(os.path.join(script_directory, "temp"))

--- a/configuration_setting_example.yaml
+++ b/configuration_setting_example.yaml
@@ -11,6 +11,14 @@ user_type: "user"
 gh_tokens:
   "raionrobotics": "ghp_mytoken_code"
 
+# Robot-authenticated OTA downloads and software snapshot reporting.
+# Environment variables override these values:
+# - RAISIN_ROBOT_API_KEY
+# - RAISIN_ROBOT_NODE
+robot:
+  api_key: ""  # Optional. Keep this local; do not commit real robot keys.
+  node: ""     # Required for robot API key auth, e.g. "jetson" or "primary".
+
 # Packages to ignore during build process(doesn't make add_subdirectory in cmakelist)
 packages_to_ignore:
   - sample_ignore_pkg  # Example package to ignore

--- a/test_install_tree.py
+++ b/test_install_tree.py
@@ -402,6 +402,25 @@ class TestRetention(InstallTreeTestCase):
         )
         self.assertEqual(kept, ["3.0.0", "4.0.0"])
 
+    def test_abandoned_staging_does_not_consume_retention_slots(self):
+        """A crash between stage and commit leaves a tree nothing points at.
+
+        Counting it toward `keep` makes the retention setting mean something
+        other than what it says, and the orphans are the newest generations so
+        they take the slots real versions should hold.
+        """
+        for v in ("1.0.0", "2.0.0", "3.0.0"):
+            self._commit(v)
+        for i in range(3):
+            it.stage_version(self.release, f"9.9.{i}")  # never committed
+
+        it.prune_versions(self.release, keep=2)
+
+        kept = sorted(
+            p.name.split("-", 1)[1] for p in (self.release / "versions").iterdir()
+        )
+        self.assertEqual(kept, ["2.0.0", "3.0.0"])
+
     def test_pruning_never_removes_the_live_or_previous_version(self):
         self._commit("1.0.0")
         self._commit("2.0.0")

--- a/test_install_tree.py
+++ b/test_install_tree.py
@@ -9,11 +9,13 @@ Layout:
 index) are unaffected; only its type changes, from directory to symlink.
 """
 
+import errno
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -204,6 +206,93 @@ class TestStageAndCommit(InstallTreeTestCase):
         )
         self.assertEqual(cloned.stat().st_ino, inode)
         self.assertNotEqual(pkg, cloned)
+
+
+class TestUnusableTreeIsReported(InstallTreeTestCase):
+    """Giving a robot a bigger package partition is a normal thing to do.
+
+    Mounting one at `release/install` puts it on a different filesystem from
+    `release/versions`, and neither `rename` nor `os.link` crosses that
+    boundary. The module docstring promises operations fail gracefully; they
+    escaped as a traceback instead.
+    """
+
+    def test_a_cross_device_migration_names_the_cause(self):
+        legacy = it.current_link(self.release)
+        legacy.mkdir()
+        (legacy / "raisin").mkdir()
+
+        def cross_device(self_, target):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+        with patch.object(Path, "rename", cross_device):
+            with self.assertRaises(it.InstallTreeUnusable) as caught:
+                it.ensure_tree(self.release)
+
+        self.assertIn("filesystem", str(caught.exception))
+
+    def test_a_clone_that_cannot_hardlink_is_reported(self):
+        self._write_pkg(it.stage_version(self.release, "1.0.0"), "pkg1", "1.0.0")
+        it.commit_version(self.release, "1.0.0")
+
+        with patch(
+            "commands.install_tree.shutil.copytree",
+            side_effect=OSError(errno.EXDEV, "Invalid cross-device link"),
+        ):
+            with self.assertRaises(it.InstallTreeUnusable):
+                it.stage_version(self.release, "2.0.0")
+
+
+class TestForeignSymlinks(InstallTreeTestCase):
+    """A robot's package tree is often deliberately put on another disk.
+
+    `release/install -> /mnt/data/raisin-install` is how an operator moves
+    1.1GB off a small root filesystem. Recovery must not read that as its own
+    broken link, because "fixing" it puts the next install back on the disk
+    they moved it off — and says it repaired something while doing it.
+    """
+
+    def _operator_link(self):
+        external = Path(self._tmp.name) / "data" / "install"
+        external.mkdir(parents=True)
+        (external / "raisin").mkdir()
+        os.symlink(external, it.current_link(self.release))
+        return external
+
+    def test_a_link_to_another_disk_is_left_alone(self):
+        external = self._operator_link()
+
+        said = it.ensure_tree(self.release)
+
+        self.assertIsNone(said)
+        self.assertTrue(it.current_link(self.release).is_symlink())
+        self.assertEqual(
+            os.path.realpath(it.current_link(self.release)),
+            os.path.realpath(external),
+        )
+
+    def test_a_link_to_another_disk_is_not_repointed_at_a_local_version(self):
+        """With versions on disk the old code silently relocated the install."""
+        external = self._operator_link()
+        stale = it.versions_dir(self.release) / "0001-old"
+        stale.mkdir(parents=True)
+
+        it.ensure_tree(self.release)
+
+        self.assertEqual(
+            os.path.realpath(it.current_link(self.release)),
+            os.path.realpath(external),
+        )
+
+    def test_our_own_dangling_link_is_still_recovered(self):
+        """The recovery this replaces must keep working for links we made."""
+        versions = it.versions_dir(self.release)
+        (versions / "0001-1.0.0").mkdir(parents=True)
+        os.symlink("versions/0002-2.0.0", it.current_link(self.release))
+
+        it.ensure_tree(self.release)
+
+        self.assertEqual(it.current_version(self.release), "1.0.0")
 
 
 class TestTamperRecovery(InstallTreeTestCase):

--- a/test_install_tree.py
+++ b/test_install_tree.py
@@ -332,6 +332,60 @@ class TestRollback(InstallTreeTestCase):
         self.assertEqual(it.current_version(self.release), "1.0.0")
 
 
+class TestMultiCommitAttempt(InstallTreeTestCase):
+    """`raisin install --install-all` commits once per build type.
+
+    Both commits belong to one attempt, so the rollback target must stay the
+    state that existed before the attempt began — not the intermediate state
+    the attempt itself produced.
+    """
+
+    def _commit(self, version, session=None, marker=None):
+        self._write_pkg(
+            it.stage_version(self.release, version), "pkg1", marker or version
+        )
+        return it.commit_version(self.release, version, session=session)
+
+    def test_second_commit_of_one_attempt_keeps_the_original_rollback_target(self):
+        self._commit("1.0.0", marker="good")  # the state to return to
+        self._commit("2.0.0-debug", session="s1", marker="debug")
+        self._commit("2.0.0", session="s1", marker="release")
+
+        self.assertEqual(it.current_version(self.release), "2.0.0")
+        self.assertEqual(it.previous_version(self.release), "1.0.0")
+
+    def test_rollback_after_a_two_stage_attempt_restores_the_pre_attempt_tree(self):
+        self._commit("1.0.0", marker="good")
+        self._commit("2.0.0-debug", session="s1", marker="debug")
+        self._commit("2.0.0", session="s1", marker="release")
+
+        it.rollback(self.release)
+
+        content = (
+            self.release
+            / "install"
+            / "pkg1"
+            / "linux"
+            / "22.04"
+            / "x86_64"
+            / "release"
+            / "release.yaml"
+        ).read_text()
+        self.assertIn("good", content)
+
+    def test_a_later_attempt_moves_the_rollback_target_forward(self):
+        self._commit("1.0.0", session="s1", marker="first")
+        self._commit("2.0.0", session="s2", marker="second")
+
+        self.assertEqual(it.previous_version(self.release), "1.0.0")
+
+    def test_commits_without_a_session_behave_as_before(self):
+        self._commit("1.0.0")
+        self._commit("2.0.0")
+
+        self.assertEqual(it.previous_version(self.release), "1.0.0")
+
+
 class TestRetention(InstallTreeTestCase):
     def _commit(self, version):
         self._write_pkg(it.stage_version(self.release, version), "pkg1", version)

--- a/test_install_tree.py
+++ b/test_install_tree.py
@@ -1,0 +1,365 @@
+"""Tests for the versioned install tree and its atomic commit point.
+
+Layout:
+
+    release/versions/<version>/   complete package tree for one archive version
+    release/install -> versions/<version>    the only thing that goes live
+
+`release/install` keeps its path so existing consumers (repo_dependency_check,
+index) are unaffected; only its type changes, from directory to symlink.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from commands import install_tree as it  # noqa: E402
+
+
+class InstallTreeTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.release = Path(self._tmp.name)
+        self.release = self.release / "release"
+        self.release.mkdir()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write_pkg(self, base: Path, name: str, marker: str = "x"):
+        """Install a package the way extraction does: replace the directory.
+
+        Editing in place would mutate the hardlink-shared previous version.
+        """
+        relative = Path(name) / "linux" / "22.04" / "x86_64" / "release"
+        d = it.replace_package_dir(base, relative)
+        (d / "release.yaml").write_text(f"version: {marker}\n", encoding="utf-8")
+        return d
+
+
+class TestLegacyMigration(InstallTreeTestCase):
+    """Robots in the field have release/install as a real directory."""
+
+    def test_existing_directory_becomes_a_version_plus_symlink(self):
+        legacy = self.release / "install"
+        self._write_pkg(legacy, "pkg1", "old")
+
+        it.migrate_legacy_tree(self.release)
+
+        link = self.release / "install"
+        self.assertTrue(link.is_symlink())
+        self.assertTrue(
+            (link / "pkg1" / "linux" / "22.04" / "x86_64" / "release" / "release.yaml")
+            .read_text()
+            .strip()
+            .endswith("old")
+        )
+
+    def test_migration_is_idempotent(self):
+        self._write_pkg(self.release / "install", "pkg1")
+        it.migrate_legacy_tree(self.release)
+        first = os.readlink(self.release / "install")
+
+        it.migrate_legacy_tree(self.release)
+
+        self.assertEqual(os.readlink(self.release / "install"), first)
+
+    def test_nothing_to_migrate_when_there_is_no_tree(self):
+        it.migrate_legacy_tree(self.release)
+
+        self.assertFalse((self.release / "install").exists())
+
+    def test_migrated_packages_are_not_copied_twice(self):
+        """A large install tree must be moved, not duplicated."""
+        legacy = self.release / "install"
+        pkg = self._write_pkg(legacy, "pkg1")
+        inode = (pkg / "release.yaml").stat().st_ino
+
+        it.migrate_legacy_tree(self.release)
+
+        moved = (
+            self.release
+            / "install"
+            / "pkg1"
+            / "linux"
+            / "22.04"
+            / "x86_64"
+            / "release"
+            / "release.yaml"
+        )
+        self.assertEqual(moved.stat().st_ino, inode)
+
+
+class TestStageAndCommit(InstallTreeTestCase):
+    def test_staging_does_not_disturb_the_live_tree(self):
+        it.migrate_legacy_tree(self.release)
+        staging = it.stage_version(self.release, "2026.2.0")
+        self._write_pkg(staging, "pkg_new")
+
+        self.assertFalse((self.release / "install").exists())
+        self.assertTrue(staging.is_dir())
+
+    def test_commit_points_the_symlink_at_the_new_version(self):
+        staging = it.stage_version(self.release, "2026.2.0")
+        self._write_pkg(staging, "pkg1", "new")
+
+        it.commit_version(self.release, "2026.2.0")
+
+        self.assertEqual(it.current_version(self.release), "2026.2.0")
+        self.assertTrue(
+            (
+                self.release
+                / "install"
+                / "pkg1"
+                / "linux"
+                / "22.04"
+                / "x86_64"
+                / "release"
+                / "release.yaml"
+            ).is_file()
+        )
+
+    def test_commit_replaces_a_previous_version_atomically(self):
+        self._write_pkg(it.stage_version(self.release, "1.0.0"), "pkg1", "old")
+        it.commit_version(self.release, "1.0.0")
+
+        self._write_pkg(it.stage_version(self.release, "2.0.0"), "pkg1", "new")
+        it.commit_version(self.release, "2.0.0")
+
+        self.assertEqual(it.current_version(self.release), "2.0.0")
+        content = (
+            self.release
+            / "install"
+            / "pkg1"
+            / "linux"
+            / "22.04"
+            / "x86_64"
+            / "release"
+            / "release.yaml"
+        ).read_text()
+        self.assertIn("new", content)
+
+    def test_previous_version_survives_a_commit(self):
+        self._write_pkg(it.stage_version(self.release, "1.0.0"), "pkg1", "old")
+        it.commit_version(self.release, "1.0.0")
+        self._write_pkg(it.stage_version(self.release, "2.0.0"), "pkg1", "new")
+        it.commit_version(self.release, "2.0.0")
+
+        self.assertEqual(it.previous_version(self.release), "1.0.0")
+
+    def test_abandoned_staging_leaves_the_live_tree_alone(self):
+        self._write_pkg(it.stage_version(self.release, "1.0.0"), "pkg1", "old")
+        it.commit_version(self.release, "1.0.0")
+
+        it.stage_version(self.release, "2.0.0")  # never committed
+
+        self.assertEqual(it.current_version(self.release), "1.0.0")
+
+    def test_staging_clones_the_current_version_for_partial_installs(self):
+        """`raisin install pkg1` must not drop the packages it did not touch."""
+        staging = it.stage_version(self.release, "1.0.0")
+        self._write_pkg(staging, "pkg1", "old")
+        self._write_pkg(staging, "pkg2", "old")
+        it.commit_version(self.release, "1.0.0")
+
+        new_staging = it.stage_version(self.release, "2.0.0")
+
+        self.assertTrue((new_staging / "pkg2").is_dir())
+
+    def test_clone_shares_storage_with_the_current_version(self):
+        """Cloning a full install tree must not double the disk footprint."""
+        staging = it.stage_version(self.release, "1.0.0")
+        pkg = self._write_pkg(staging, "pkg1")
+        it.commit_version(self.release, "1.0.0")
+        inode = (
+            (
+                self.release
+                / "install"
+                / "pkg1"
+                / "linux"
+                / "22.04"
+                / "x86_64"
+                / "release"
+                / "release.yaml"
+            )
+            .stat()
+            .st_ino
+        )
+
+        new_staging = it.stage_version(self.release, "2.0.0")
+
+        cloned = (
+            new_staging
+            / "pkg1"
+            / "linux"
+            / "22.04"
+            / "x86_64"
+            / "release"
+            / "release.yaml"
+        )
+        self.assertEqual(cloned.stat().st_ino, inode)
+        self.assertNotEqual(pkg, cloned)
+
+
+class TestTamperRecovery(InstallTreeTestCase):
+    """The symlink is one `rm` away from being wrong. Detect it, do not trust it."""
+
+    def _commit(self, version):
+        self._write_pkg(it.stage_version(self.release, version), "pkg1", version)
+        it.commit_version(self.release, version)
+
+    def test_dangling_symlink_is_not_reported_as_installed(self):
+        """Trusting it would report a version that is not on disk to the server."""
+        self._commit("1.0.0")
+        self._commit("2.0.0")
+        shutil.rmtree(self.release / "versions" / "0002-2.0.0")
+
+        self.assertIsNone(it.current_version(self.release))
+
+    def test_dangling_symlink_heals_to_a_surviving_version(self):
+        self._commit("1.0.0")
+        self._commit("2.0.0")
+        shutil.rmtree(self.release / "versions" / "0002-2.0.0")
+
+        it.ensure_tree(self.release)
+
+        self.assertEqual(it.current_version(self.release), "1.0.0")
+        self.assertIn(
+            "1.0.0",
+            (
+                self.release
+                / "install"
+                / "pkg1"
+                / "linux"
+                / "22.04"
+                / "x86_64"
+                / "release"
+                / "release.yaml"
+            ).read_text(),
+        )
+
+    def test_deleted_symlink_is_relinked_to_the_newest_version(self):
+        """`rm -rf release/install` removes the link; the packages survive."""
+        self._commit("1.0.0")
+        self._commit("2.0.0")
+        (self.release / "install").unlink()
+
+        it.ensure_tree(self.release)
+
+        self.assertEqual(it.current_version(self.release), "2.0.0")
+
+    def test_recovery_is_a_noop_when_nothing_was_touched(self):
+        self._commit("1.0.0")
+        self._commit("2.0.0")
+
+        it.ensure_tree(self.release)
+
+        self.assertEqual(it.current_version(self.release), "2.0.0")
+        self.assertEqual(it.previous_version(self.release), "1.0.0")
+
+    def test_symlink_replaced_by_a_real_directory_is_absorbed(self):
+        self._commit("1.0.0")
+        (self.release / "install").unlink()
+        restored = self.release / "install"
+        self._write_pkg(restored, "pkg1", "restored")
+
+        it.ensure_tree(self.release)
+
+        self.assertTrue((self.release / "install").is_symlink())
+        self.assertIn(
+            "restored",
+            (
+                self.release
+                / "install"
+                / "pkg1"
+                / "linux"
+                / "22.04"
+                / "x86_64"
+                / "release"
+                / "release.yaml"
+            ).read_text(),
+        )
+
+    def test_no_versions_and_no_link_is_left_alone(self):
+        it.ensure_tree(self.release)
+
+        self.assertFalse((self.release / "install").exists())
+
+    def test_stale_previous_pointer_is_ignored(self):
+        """Deleting the rollback target must not leave rollback claiming to work."""
+        self._commit("1.0.0")
+        self._commit("2.0.0")
+        shutil.rmtree(self.release / "versions" / "0001-1.0.0")
+
+        self.assertIsNone(it.previous_version(self.release))
+        self.assertIsNone(it.rollback(self.release))
+        self.assertEqual(it.current_version(self.release), "2.0.0")
+
+
+class TestRollback(InstallTreeTestCase):
+    def test_rollback_restores_the_previous_version(self):
+        self._write_pkg(it.stage_version(self.release, "1.0.0"), "pkg1", "old")
+        it.commit_version(self.release, "1.0.0")
+        self._write_pkg(it.stage_version(self.release, "2.0.0"), "pkg1", "new")
+        it.commit_version(self.release, "2.0.0")
+
+        restored = it.rollback(self.release)
+
+        self.assertEqual(restored, "1.0.0")
+        self.assertEqual(it.current_version(self.release), "1.0.0")
+        content = (
+            self.release
+            / "install"
+            / "pkg1"
+            / "linux"
+            / "22.04"
+            / "x86_64"
+            / "release"
+            / "release.yaml"
+        ).read_text()
+        self.assertIn("old", content)
+
+    def test_rollback_without_a_previous_version_reports_it(self):
+        self._write_pkg(it.stage_version(self.release, "1.0.0"), "pkg1")
+        it.commit_version(self.release, "1.0.0")
+
+        self.assertIsNone(it.rollback(self.release))
+        self.assertEqual(it.current_version(self.release), "1.0.0")
+
+
+class TestRetention(InstallTreeTestCase):
+    def _commit(self, version):
+        self._write_pkg(it.stage_version(self.release, version), "pkg1", version)
+        it.commit_version(self.release, version)
+
+    def test_old_versions_are_pruned_to_the_keep_count(self):
+        for v in ("1.0.0", "2.0.0", "3.0.0", "4.0.0"):
+            self._commit(v)
+
+        it.prune_versions(self.release, keep=2)
+
+        kept = sorted(
+            p.name.split("-", 1)[1] for p in (self.release / "versions").iterdir()
+        )
+        self.assertEqual(kept, ["3.0.0", "4.0.0"])
+
+    def test_pruning_never_removes_the_live_or_previous_version(self):
+        self._commit("1.0.0")
+        self._commit("2.0.0")
+
+        it.prune_versions(self.release, keep=1)
+
+        kept = sorted(
+            p.name.split("-", 1)[1] for p in (self.release / "versions").iterdir()
+        )
+        self.assertIn("2.0.0", kept)  # live
+        self.assertIn("1.0.0", kept)  # rollback target
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_ota.py
+++ b/test_ota.py
@@ -1007,6 +1007,161 @@ class TestMalformedReleaseYaml(unittest.TestCase):
         self.assertEqual(result["dependencies"], ["depA"])
 
 
+class TestHaltStopsTheInstall(unittest.TestCase):
+    """A halt tells this node to stop. It is not "no archive available".
+
+    Both are `{}` today, and `install_command` reads `{}` as a reason to
+    install from GitHub instead — through the per-package route, which writes
+    straight into the live tree with no staging and no rollback. So a halt did
+    not stop the robot, it moved it to another source.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = g.script_directory
+        g.script_directory = self._tmp.name
+        _sync_ota_context()
+        self.live = Path(self._tmp.name) / "release" / "install"
+        self.live.parent.mkdir(parents=True)
+
+    def tearDown(self):
+        g.script_directory = self._orig
+        self._tmp.cleanup()
+
+    def test_a_halted_node_raises_rather_than_returning_nothing(self):
+        _as_robot(self)
+
+        with patch(
+            "commands.ota_client._resolve_desired_state",
+            return_value=(True, None, None, None),
+        ):
+            with self.assertRaises(ota.OtaInstallHalted):
+                ota.download_all_from_archive("release", self.live)
+
+    @patch("commands.install.load_configuration")
+    def test_a_halt_does_not_send_the_robot_to_github(self, mock_config):
+        mock_config.return_value = (
+            {"mypkg": {"url": "git@github.com:org/mypkg.git"}},
+            {"org": "ghtoken"},
+            "devel",
+            None,
+            [],
+        )
+        from commands.install import install_command
+
+        with patch(
+            "commands.install.download_all_from_archive",
+            side_effect=ota.OtaInstallHalted("halted by tenant"),
+        ), patch("commands.ota_client.download_package") as mock_download, patch(
+            "commands.install.requests.Session"
+        ):
+            result = install_command([], "release")
+
+        self.assertFalse(result)
+        mock_download.assert_not_called()
+
+
+class TestUnusableTreeStopsTheInstall(unittest.TestCase):
+    """A tree that cannot be prepared is not "OTA unavailable".
+
+    Falling back would install the same packages one at a time into the same
+    place, without staging or a rollback — on a robot whose install path is
+    already the problem.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = g.script_directory
+        g.script_directory = self._tmp.name
+        _sync_ota_context()
+
+    def tearDown(self):
+        g.script_directory = self._orig
+        self._tmp.cleanup()
+
+    @patch("commands.install.load_configuration")
+    def test_a_cross_device_tree_does_not_fall_back_to_github(self, mock_config):
+        mock_config.return_value = (
+            {"mypkg": {"url": "git@github.com:org/mypkg.git"}},
+            {"org": "ghtoken"},
+            "devel",
+            None,
+            [],
+        )
+        from commands.install import install_command
+
+        with patch(
+            "commands.install.download_all_from_archive",
+            side_effect=install_tree.InstallTreeUnusable(
+                "release/install and release/versions are on different filesystems"
+            ),
+        ), patch("commands.ota_client.download_package") as mock_download, patch(
+            "commands.install.requests.Session"
+        ), patch(
+            "builtins.print"
+        ) as mock_print:
+            result = install_command([], "release")
+
+        self.assertFalse(result)
+        mock_download.assert_not_called()
+        output = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("different filesystems", output)
+
+
+class TestNodeLevelArchivePin(unittest.TestCase):
+    """`RAISIN_ARCHIVE_NAME` pins one node, and a pin outranks the fleet.
+
+    The README this PR adds says so. Both pin checks look only at the call
+    argument, so the env var lost to desired state and also fell through to
+    GitHub — the opposite of what an operator setting it would expect.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = g.script_directory
+        g.script_directory = self._tmp.name
+        _sync_ota_context()
+
+    def tearDown(self):
+        g.script_directory = self._orig
+        self._tmp.cleanup()
+
+    @patch("commands.ota_client._fetch_archive_manifest", return_value=None)
+    @patch("commands.ota_client._resolve_desired_state")
+    def test_an_env_pinned_archive_outranks_desired_state(
+        self, mock_desired, _mock_fetch
+    ):
+        with patch.dict(os.environ, {"RAISIN_ARCHIVE_NAME": "node-archive"}):
+            ota.download_all_from_archive(
+                "release", Path(self._tmp.name) / "release" / "install"
+            )
+
+        mock_desired.assert_not_called()
+
+    @patch("commands.install.load_configuration")
+    def test_an_env_pinned_archive_refuses_the_github_fallback(self, mock_config):
+        mock_config.return_value = (
+            {"mypkg": {"url": "git@github.com:org/mypkg.git"}},
+            {"org": "ghtoken"},
+            "devel",
+            None,
+            [],
+        )
+        from commands.install import install_command
+
+        with patch(
+            "commands.install.download_all_from_archive", return_value={}
+        ), patch("commands.ota_client.download_package") as mock_download, patch(
+            "commands.install.requests.Session"
+        ), patch.dict(
+            os.environ, {"RAISIN_ARCHIVE_NAME": "node-archive"}
+        ):
+            result = install_command([], "release")
+
+        self.assertFalse(result)
+        mock_download.assert_not_called()
+
+
 class TestPackageLookup(unittest.TestCase):
     """`GET /packages` takes search/page/limit — not `name`, and limit caps at 100.
 
@@ -1172,6 +1327,55 @@ class TestInstallEventQueue(unittest.TestCase):
 
     def _queued(self):
         return ota._read_install_event_queue()
+
+    def test_the_event_buffer_survives_a_full_build(self):
+        """`setup(package_name="")` deletes `<workspace>/install` on every build.
+
+        Outliving that is the whole reason the queue is on disk: a robot that
+        was offline when it failed reports on a later run, and a build in
+        between must not erase what it was going to say.
+        """
+        ota.record_install_event("started", archive_name="dso")
+        self.assertEqual(len(self._queued()), 1)
+
+        shutil.rmtree(Path(g.script_directory) / "install", ignore_errors=True)
+
+        self.assertEqual(len(self._queued()), 1)
+
+    def test_a_buffer_left_at_the_old_location_is_carried_over(self):
+        """An upgrade must not throw away what the previous client buffered."""
+        legacy = Path(g.script_directory) / "install" / ota._INSTALL_EVENT_QUEUE_FILE
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text(
+            json.dumps({"eventId": "old-1", "eventType": "started"}) + "\n",
+            encoding="utf-8",
+        )
+
+        self.assertEqual([e["eventId"] for e in self._queued()], ["old-1"])
+
+    @patch("commands.ota_client.requests.post")
+    def test_acks_for_events_we_never_sent_do_not_spin(self, mock_post):
+        """The guard must watch our queue, not whether the response was empty."""
+        ota.record_install_event("started", archive_name="dso")
+        posts = []
+
+        def respond(*args, **kwargs):
+            posts.append(1)
+            if len(posts) > 4:
+                raise AssertionError(
+                    f"flush reposted a 1-event queue {len(posts)} times"
+                )
+            return _mock_response(
+                json_data={"data": {"acks": [{"eventId": "an-id-we-never-sent"}]}}
+            )
+
+        mock_post.side_effect = respond
+
+        result = ota.flush_install_events()
+
+        self.assertFalse(result)
+        self.assertEqual(len(self._queued()), 1)
+        self.assertEqual(len(posts), 1)
 
     def test_recorded_event_carries_the_contract_fields(self):
         ota.record_install_event("started", archive_name="dso")
@@ -1364,9 +1568,12 @@ class TestInstallEventQueue(unittest.TestCase):
 
     def test_flush_without_robot_auth_is_a_noop_that_keeps_the_queue(self):
         ota.record_install_event("started")
+        # The identity is injected, not read from the environment — clearing
+        # the environment leaves it in place and the flush reaches the live
+        # server, which answers 401 and makes this pass for the wrong reason.
+        _as_robot(self, None)
 
-        with patch.dict(os.environ, {}, clear=True):
-            ok = ota.flush_install_events()
+        ok = ota.flush_install_events()
 
         self.assertFalse(ok)
         self.assertEqual(len(self._queued()), 1)
@@ -1601,6 +1808,11 @@ class TestTransactionalArchiveInstall(unittest.TestCase):
         "2026.2.0",
     )
 
+    def _staged_dirs(self):
+        """Every directory under versions/, including ones the pattern misses."""
+        base = install_tree.versions_dir(self.release)
+        return sorted(e.name for e in base.iterdir()) if base.is_dir() else []
+
     def _extract_into(self, staging_names):
         """Stand in for extraction: write each package into the staged tree."""
 
@@ -1654,6 +1866,50 @@ class TestTransactionalArchiveInstall(unittest.TestCase):
         self.assertEqual(results, {})
         self.assertIsNone(install_tree.current_version(self.release))
         self.assertIsNotNone(ota.pending_install_failure())
+
+    def test_an_archive_with_no_version_is_refused_before_staging(self):
+        """The version becomes a directory name, so a falsy one cannot commit."""
+        with patch(
+            "commands.ota_client._fetch_archive_manifest",
+            return_value=(self.MANIFEST[0], "arch-1", None),
+        ):
+            results = ota.download_all_from_archive(
+                "release", self.live, archive_version="2026.2.0"
+            )
+
+        self.assertEqual(results, {})
+        self.assertEqual(self._staged_dirs(), [])
+        self.assertFalse(self.live.exists())
+
+    def test_an_archive_with_an_empty_version_is_refused(self):
+        """`0001-` does not match the generation pattern, so the tree loses it."""
+        with patch(
+            "commands.ota_client._fetch_archive_manifest",
+            return_value=(self.MANIFEST[0], "arch-1", ""),
+        ):
+            results = ota.download_all_from_archive(
+                "release", self.live, archive_version="2026.2.0"
+            )
+
+        self.assertEqual(results, {})
+        self.assertEqual(self._staged_dirs(), [])
+
+    def test_a_commit_that_did_not_happen_is_not_reported_as_success(self):
+        """The symlink is what makes an install real; if it did not move, nothing did."""
+        self._run({"pkg1", "pkg2"})
+        ota.clear_pending_install_failure()
+        ota._install_session_id = "session-tx-nocommit"
+
+        with patch("commands.install_tree.commit_version", return_value=None), patch(
+            "builtins.print"
+        ) as mock_print:
+            results = self._run({"pkg1", "pkg2"})
+
+        self.assertEqual(results, {})
+        self.assertIsNotNone(ota.pending_install_failure())
+        self.assertEqual(install_tree.current_version(self.release), "2026.2.0")
+        output = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertNotIn("Switched", output)
 
     def test_previous_version_keeps_running_when_an_install_fails(self):
         self._run({"pkg1", "pkg2"})
@@ -2025,6 +2281,36 @@ class TestResumableDownload(unittest.TestCase):
         self.assertEqual(code, "network")
         self.assertFalse(self.dest.exists())
         self.assertEqual(self.part.read_bytes(), self.BODY[:8])
+
+    def test_a_partial_that_is_already_whole_restarts_instead_of_sticking(self):
+        """A crash between the digest check and the rename leaves a full `.part`.
+
+        Asking to resume past the end of the object is a 416, which is not a
+        server fault and not retryable — so without recovery this package fails
+        identically on every run until the partial ages out.
+        """
+        self.part.write_bytes(self.BODY)
+        ota._write_part_state(self.part, self.digest)
+
+        refused = _mock_response(status_code=416, headers={})
+        refused.raise_for_status.side_effect = requests.HTTPError(response=refused)
+        sent = []
+
+        def get(url, headers=None, **kwargs):
+            sent.append(dict(headers or {}))
+            return refused if len(sent) == 1 else self._resp(self.BODY)
+
+        with patch("commands.ota_client.requests.get", side_effect=get), patch(
+            "commands.ota_client.time.sleep"
+        ):
+            ok, code = ota._download_to_path(
+                "https://ota.example.com/x", self.dest, max_attempts=1
+            )
+
+        self.assertTrue(ok, f"failed with {code}")
+        self.assertEqual(self.dest.read_bytes(), self.BODY)
+        self.assertIn("Range", sent[0])
+        self.assertNotIn("Range", sent[1], "the retry must start from zero")
 
     def test_resume_sends_range_and_if_range_for_an_existing_part(self):
         self.part.write_bytes(self.BODY[:8])
@@ -3423,9 +3709,9 @@ class TestDownload(unittest.TestCase):
         mock_desired.return_value = (True, None, None, None)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            result = ota.download_all_from_archive("release", Path(tmpdir))
+            with self.assertRaises(ota.OtaInstallHalted):
+                ota.download_all_from_archive("release", Path(tmpdir))
 
-        self.assertEqual(result, {})
         mock_fetch.assert_not_called()
 
     @patch("commands.ota_client._fetch_archive_manifest", return_value=None)

--- a/test_ota.py
+++ b/test_ota.py
@@ -1799,6 +1799,22 @@ class TestResumableDownload(unittest.TestCase):
         self.assertEqual(code, "network")
         self.assertFalse(self.dest.exists())
 
+    def test_a_stale_partial_is_discarded_rather_than_resumed(self):
+        """A .part nobody came back for should not be appended to forever."""
+        self.part.write_bytes(self.BODY[:8])
+        ota._write_part_state(self.part, self.digest)
+        stale = time.time() - (ota._PART_MAX_AGE_SECONDS + 60)
+        os.utime(self.part, (stale, stale))
+
+        with patch(
+            "commands.ota_client.requests.get", return_value=self._resp(self.BODY)
+        ) as mock_get:
+            ok, _ = ota._download_to_path("https://ota.example.com/x", self.dest)
+
+        self.assertTrue(ok)
+        self.assertEqual(self.dest.read_bytes(), self.BODY)
+        self.assertNotIn("Range", mock_get.call_args.kwargs["headers"])
+
     def test_server_ignoring_range_restarts_cleanly(self):
         """A 200 answer to a Range request means the object changed."""
         self.part.write_bytes(b"stale-prefix")
@@ -3466,7 +3482,7 @@ class TestInstallCliEventReporting(unittest.TestCase):
             try:
                 # It is a click Command; call the underlying function.
                 install_mod.install_cli_command.callback(
-                    ["mypkg"], "release", False, None, None, None, False, "stable"
+                    ["mypkg"], "release", None, None, None, False, "stable"
                 )
             except click.exceptions.Exit:
                 pass

--- a/test_ota.py
+++ b/test_ota.py
@@ -1071,6 +1071,30 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(call_args.kwargs["json"]["installSessionId"], "session-1")
         self.assertEqual(call_args.kwargs["json"]["clientVersion"], "raisin-cli-test")
 
+    def test_collect_archive_snapshot_packages_ignores_non_object_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_base = Path(tmpdir) / "release" / "install"
+            metadata_path = (
+                install_base
+                / "mypkg"
+                / "linux"
+                / "22.04"
+                / "x86_64"
+                / "release"
+                / ota._INSTALL_METADATA_FILE
+            )
+            metadata_path.parent.mkdir(parents=True, exist_ok=True)
+            metadata_path.write_text("[]", encoding="utf-8")
+
+            packages = ota._collect_archive_snapshot_packages(
+                install_base,
+                "arch-1",
+                "linux-22.04-x86_64",
+                "release",
+            )
+
+        self.assertEqual(packages, [])
+
     @patch("commands.ota_client._fetch_archive_by_tag")
     @patch("commands.ota_client._download_package_blob")
     def test_download_all_uses_tag_when_provided(self, mock_dl, mock_fetch_by_tag):

--- a/test_ota.py
+++ b/test_ota.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import base64
+import errno
 import hashlib
 import json
 import os
@@ -21,6 +22,8 @@ import tempfile
 import time
 import unittest
 import zipfile
+
+import requests
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
 from click.testing import CliRunner
@@ -766,6 +769,385 @@ class TestUpload(unittest.TestCase):
 
 
 # ============================================================================
+# 4b. Download Failure Classification
+# ============================================================================
+
+
+class TestDownloadErrorClassification(unittest.TestCase):
+    """Map download failures onto the install-event error taxonomy.
+
+    Codes come from the server contract (docs/ota-install-event-contract.md):
+    network, timeout, hash_mismatch, disk_full, server_error, unknown.
+    """
+
+    def test_connection_error_is_network(self):
+        self.assertEqual(
+            ota.classify_download_error(requests.ConnectionError("refused")),
+            "network",
+        )
+
+    def test_read_timeout_is_timeout(self):
+        self.assertEqual(
+            ota.classify_download_error(requests.Timeout("read timed out")),
+            "timeout",
+        )
+
+    def test_server_5xx_is_server_error(self):
+        resp = _mock_response(status_code=503)
+        self.assertEqual(
+            ota.classify_download_error(requests.HTTPError(response=resp)),
+            "server_error",
+        )
+
+    def test_client_4xx_is_not_server_error(self):
+        """A 404 is a real answer, not an outage — retrying it is pointless."""
+        resp = _mock_response(status_code=404)
+        self.assertEqual(
+            ota.classify_download_error(requests.HTTPError(response=resp)),
+            "unknown",
+        )
+
+    def test_enospc_is_disk_full(self):
+        self.assertEqual(
+            ota.classify_download_error(OSError(errno.ENOSPC, "No space left")),
+            "disk_full",
+        )
+
+    def test_hash_mismatch_is_reported_as_such(self):
+        self.assertEqual(
+            ota.classify_download_error(ota.ContentHashMismatch("bad digest")),
+            "hash_mismatch",
+        )
+
+    def test_unrecognised_failure_is_unknown(self):
+        self.assertEqual(ota.classify_download_error(ValueError("?")), "unknown")
+
+    def test_retryable_codes_exclude_permanent_failures(self):
+        """Backoff must not burn attempts on something that cannot improve."""
+        self.assertTrue(ota.is_retryable_error_code("network"))
+        self.assertTrue(ota.is_retryable_error_code("timeout"))
+        self.assertTrue(ota.is_retryable_error_code("server_error"))
+        self.assertTrue(ota.is_retryable_error_code("hash_mismatch"))
+        self.assertFalse(ota.is_retryable_error_code("disk_full"))
+        self.assertFalse(ota.is_retryable_error_code("unknown"))
+
+
+class TestInstallSessionPersistence(unittest.TestCase):
+    """A resumed install must keep its session id.
+
+    #47 pins download authorization to the archive the session resolved to at
+    session start, so a crash-and-retry that invents a new id loses the pin and
+    the partial file it was resuming.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_script_directory = g.script_directory
+        g.script_directory = self._tmp.name
+        ota._install_session_id = None
+
+    def tearDown(self):
+        ota._install_session_id = None
+        g.script_directory = self._orig_script_directory
+        self._tmp.cleanup()
+
+    def _new_process(self):
+        """Simulate a fresh CLI process: module state gone, disk state kept."""
+        ota._install_session_id = None
+
+    def test_session_id_is_stable_within_a_process(self):
+        self.assertEqual(ota.get_install_session_id(), ota.get_install_session_id())
+
+    def test_session_id_survives_a_process_restart(self):
+        first = ota.get_install_session_id()
+        self._new_process()
+
+        self.assertEqual(ota.get_install_session_id(), first)
+
+    def test_clearing_the_session_starts_a_new_one(self):
+        first = ota.get_install_session_id()
+        ota.clear_install_session()
+        self._new_process()
+
+        self.assertNotEqual(ota.get_install_session_id(), first)
+
+    def test_stale_session_is_not_resumed(self):
+        """A session left behind by an install abandoned days ago is not ours."""
+        first = ota.get_install_session_id()
+        path = ota._install_session_path()
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["startedAt"] = time.time() - (ota._INSTALL_SESSION_TTL_SECONDS + 60)
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        self._new_process()
+
+        self.assertNotEqual(ota.get_install_session_id(), first)
+
+    def test_corrupt_session_file_does_not_break_the_install(self):
+        ota._install_session_path().parent.mkdir(parents=True, exist_ok=True)
+        ota._install_session_path().write_text("{not json", encoding="utf-8")
+        self._new_process()
+
+        self.assertTrue(ota.get_install_session_id())
+
+
+class TestDownloadBlobErrorPropagation(unittest.TestCase):
+    """`_download_package_blob` reports *why* it failed, not just that it did.
+
+    #29 attaches the code to a terminal install event, so it has to survive the
+    trip out of the download layer.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.dest = Path(self._tmp.name) / "pkg.zip"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _call(self, **env):
+        with patch.dict(os.environ, env, clear=True), patch(
+            "commands.ota_client.get_ota_endpoint",
+            return_value="https://ota.example.com",
+        ):
+            return ota._download_package_blob(
+                "arch-1",
+                "pkg-1",
+                "mypkg",
+                self.dest,
+                archive_name="dso",
+                archive_version="1.0.3",
+                platform_str="ubuntu-24.04-arm64",
+                install_session_id="session-1",
+            )
+
+    def test_success_reports_no_error_code(self):
+        body = b"payload"
+        resp = _mock_response(
+            iter_content=[body],
+            headers={"X-Content-Hash": hashlib.sha256(body).hexdigest()},
+        )
+        with patch("commands.ota_client.requests.get", return_value=resp):
+            ok, code = self._call(
+                RAISIN_ROBOT_API_KEY="robot-key",  # pragma: allowlist secret
+                RAISIN_ROBOT_NODE="jetson",
+            )
+
+        self.assertTrue(ok)
+        self.assertIsNone(code)
+
+    def test_robot_path_propagates_the_taxonomy_code(self):
+        with patch(
+            "commands.ota_client.requests.get",
+            side_effect=requests.ConnectionError("refused"),
+        ), patch("commands.ota_client.time.sleep"):
+            ok, code = self._call(
+                RAISIN_ROBOT_API_KEY="robot-key",  # pragma: allowlist secret
+                RAISIN_ROBOT_NODE="jetson",
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(code, "network")
+
+    @patch("commands.ota_client._get_auth_context", return_value=("tok", {}))
+    def test_legacy_path_propagates_the_taxonomy_code(self, _ctx):
+        resp = _mock_response(status_code=503)
+        with patch(
+            "commands.ota_client.requests.get",
+            side_effect=requests.HTTPError(response=resp),
+        ), patch("commands.ota_client.time.sleep"):
+            ok, code = self._call()
+
+        self.assertFalse(ok)
+        self.assertEqual(code, "server_error")
+
+
+class TestResumableDownload(unittest.TestCase):
+    """`_download_to_path`: atomic rename, resume, disk preflight, backoff."""
+
+    BODY = b"raisin-package-payload"
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.dest = Path(self._tmp.name) / "pkg.zip"
+        self.part = self.dest.with_name(self.dest.name + ".part")
+        self.digest = hashlib.sha256(self.BODY).hexdigest()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _resp(self, body, status=200, extra_headers=None):
+        headers = {"X-Content-Hash": self.digest, "Content-Length": str(len(body))}
+        headers.update(extra_headers or {})
+        return _mock_response(status_code=status, iter_content=[body], headers=headers)
+
+    def test_successful_download_lands_at_final_path(self):
+        with patch(
+            "commands.ota_client.requests.get", return_value=self._resp(self.BODY)
+        ):
+            ok, code = ota._download_to_path("https://ota.example.com/x", self.dest)
+
+        self.assertTrue(ok)
+        self.assertIsNone(code)
+        self.assertEqual(self.dest.read_bytes(), self.BODY)
+        self.assertFalse(self.part.exists())
+
+    def test_hash_mismatch_never_leaves_a_file_at_the_final_path(self):
+        """A corrupt body must not be visible where the installer looks."""
+        bad = _mock_response(
+            iter_content=[b"corrupted"],
+            headers={"X-Content-Hash": self.digest, "Content-Length": "9"},
+        )
+        with patch("commands.ota_client.requests.get", return_value=bad), patch(
+            "commands.ota_client.time.sleep"
+        ):
+            ok, code = ota._download_to_path(
+                "https://ota.example.com/x", self.dest, max_attempts=1
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(code, "hash_mismatch")
+        self.assertFalse(self.dest.exists())
+
+    def test_interrupted_download_leaves_only_a_part_file(self):
+        """The partial stays for resume, but never under the final name."""
+
+        def explode():
+            yield self.BODY[:8]
+            raise requests.ConnectionError("reset")
+
+        resp = _mock_response(
+            iter_content=explode(),
+            headers={
+                "X-Content-Hash": self.digest,
+                "Content-Length": str(len(self.BODY)),
+            },
+        )
+        with patch("commands.ota_client.requests.get", return_value=resp), patch(
+            "commands.ota_client.time.sleep"
+        ):
+            ok, code = ota._download_to_path(
+                "https://ota.example.com/x", self.dest, max_attempts=1
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(code, "network")
+        self.assertFalse(self.dest.exists())
+        self.assertEqual(self.part.read_bytes(), self.BODY[:8])
+
+    def test_resume_sends_range_and_if_range_for_an_existing_part(self):
+        self.part.write_bytes(self.BODY[:8])
+        ota._write_part_state(self.part, self.digest)
+
+        resp = _mock_response(
+            status_code=206,
+            iter_content=[self.BODY[8:]],
+            headers={
+                "X-Content-Hash": self.digest,
+                "Content-Range": f"bytes 8-{len(self.BODY) - 1}/{len(self.BODY)}",
+            },
+        )
+        with patch("commands.ota_client.requests.get", return_value=resp) as mock_get:
+            ok, _ = ota._download_to_path("https://ota.example.com/x", self.dest)
+
+        sent = mock_get.call_args.kwargs["headers"]
+        self.assertEqual(sent["Range"], "bytes=8-")
+        self.assertEqual(sent["If-Range"], f'"{self.digest}"')
+        self.assertTrue(ok)
+        self.assertEqual(self.dest.read_bytes(), self.BODY)
+
+    def test_server_ignoring_range_restarts_cleanly(self):
+        """A 200 answer to a Range request means the object changed."""
+        self.part.write_bytes(b"stale-prefix")
+        ota._write_part_state(self.part, "0" * 64)
+
+        with patch(
+            "commands.ota_client.requests.get", return_value=self._resp(self.BODY)
+        ):
+            ok, _ = ota._download_to_path("https://ota.example.com/x", self.dest)
+
+        self.assertTrue(ok)
+        self.assertEqual(self.dest.read_bytes(), self.BODY)
+
+    def test_insufficient_disk_space_fails_before_writing(self):
+        usage = MagicMock(free=16)
+        with patch("commands.ota_client.shutil.disk_usage", return_value=usage), patch(
+            "commands.ota_client.requests.get", return_value=self._resp(self.BODY)
+        ):
+            ok, code = ota._download_to_path(
+                "https://ota.example.com/x", self.dest, max_attempts=1
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(code, "disk_full")
+        self.assertFalse(self.dest.exists())
+
+    def test_transient_failure_is_retried_then_succeeds(self):
+        responses = [
+            requests.ConnectionError("reset"),
+            self._resp(self.BODY),
+        ]
+
+        def side_effect(*a, **kw):
+            item = responses.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        with patch("commands.ota_client.requests.get", side_effect=side_effect), patch(
+            "commands.ota_client.time.sleep"
+        ) as mock_sleep:
+            ok, code = ota._download_to_path("https://ota.example.com/x", self.dest)
+
+        self.assertTrue(ok)
+        self.assertIsNone(code)
+        self.assertEqual(mock_sleep.call_count, 1)
+
+    def test_retries_are_capped_and_report_the_last_error(self):
+        with patch(
+            "commands.ota_client.requests.get",
+            side_effect=requests.ConnectionError("reset"),
+        ) as mock_get, patch("commands.ota_client.time.sleep"):
+            ok, code = ota._download_to_path(
+                "https://ota.example.com/x", self.dest, max_attempts=3
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(code, "network")
+        self.assertEqual(mock_get.call_count, 3)
+
+    def test_permanent_failure_is_not_retried(self):
+        usage = MagicMock(free=1)
+        with patch("commands.ota_client.shutil.disk_usage", return_value=usage), patch(
+            "commands.ota_client.requests.get", return_value=self._resp(self.BODY)
+        ) as mock_get, patch("commands.ota_client.time.sleep"):
+            ok, code = ota._download_to_path(
+                "https://ota.example.com/x", self.dest, max_attempts=5
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(code, "disk_full")
+        self.assertEqual(mock_get.call_count, 1)
+
+    def test_backoff_is_exponential_and_jittered(self):
+        delays = []
+        with patch(
+            "commands.ota_client.requests.get",
+            side_effect=requests.ConnectionError("reset"),
+        ), patch("commands.ota_client.time.sleep", side_effect=delays.append):
+            ota._download_to_path(
+                "https://ota.example.com/x", self.dest, max_attempts=4
+            )
+
+        self.assertEqual(len(delays), 3)
+        # Each window doubles; jitter keeps the delay inside it, so a
+        # synchronised fleet does not retry in lockstep.
+        for i, delay in enumerate(delays):
+            self.assertGreater(delay, 0)
+            self.assertLessEqual(delay, ota._BACKOFF_BASE_SECONDS * (2**i))
+        self.assertNotEqual(len(set(delays)), 1)
+
+
+# ============================================================================
 # 5. Download Tests
 # ============================================================================
 
@@ -1160,21 +1542,28 @@ class TestDownload(unittest.TestCase):
 
     @patch("commands.ota_client._get_auth_context", return_value=("tok", {}))
     @patch("commands.ota_client.requests.get")
-    def test_stream_download_removes_partial_file_on_failure(self, mock_get, _auth):
+    def test_stream_download_never_leaves_a_partial_at_the_final_path(
+        self, mock_get, _auth
+    ):
         def chunks():
             yield b"partial"
             raise ota.requests.ConnectionError("connection lost")
 
-        mock_get.return_value = _mock_response(iter_content=chunks())
+        mock_get.return_value = _mock_response(
+            iter_content=chunks(), headers={"Content-Length": "20"}
+        )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory() as tmpdir, patch(
+            "commands.ota_client.time.sleep"
+        ):
             download_path = Path(tmpdir) / "pkg.zip"
 
-            result = ota._stream_download(
+            ok, code = ota._stream_download(
                 "https://ota.example.com/pkg.zip", download_path, "mypkg"
             )
 
-            self.assertFalse(result)
+            self.assertFalse(ok)
+            self.assertEqual(code, "network")
             self.assertFalse(download_path.exists())
 
     @patch("commands.ota_client._stream_download", return_value=True)
@@ -1290,7 +1679,7 @@ class TestDownload(unittest.TestCase):
             "arch-tagged",
             "v1.0.97",
         )
-        mock_dl.return_value = True
+        mock_dl.return_value = (True, None)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             ota.download_all_from_archive("release", Path(tmpdir), tag="stable")
@@ -1312,7 +1701,7 @@ class TestDownload(unittest.TestCase):
             )
         self.assertEqual(result, {})
 
-    @patch("commands.ota_client._download_package_blob", return_value=True)
+    @patch("commands.ota_client._download_package_blob", return_value=(True, None))
     @patch("commands.ota_client._fetch_archive_by_tag")
     def test_download_all_falls_back_to_stable_when_requested_tag_missing(
         self, mock_fetch_by_tag, _mock_dl
@@ -1350,7 +1739,7 @@ class TestDownload(unittest.TestCase):
         self, mock_dl, mock_by_tag, mock_by_version
     ):
         mock_by_version.return_value = ([], "arch-v", "v1.0.97")
-        mock_dl.return_value = True
+        mock_dl.return_value = (True, None)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             ota.download_all_from_archive(
@@ -1375,7 +1764,7 @@ class TestDownload(unittest.TestCase):
             },
         ]
         mock_manifest.return_value = (packages, "arch-1", "v2024.01")
-        mock_blob.return_value = True
+        mock_blob.return_value = (True, None)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
@@ -1393,7 +1782,7 @@ class TestDownload(unittest.TestCase):
             # Make _download_package_blob write the zip to disk (already done)
             def fake_download(archive_id, pkg_id, name, path, **_kwargs):
                 # File already written above
-                return True
+                return (True, None)
 
             mock_blob.side_effect = fake_download
 
@@ -1426,7 +1815,7 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(metadata["requestedArchiveVersion"], None)
         self.assertIn("installedAt", metadata)
 
-    @patch("commands.ota_client._download_package_blob", return_value=True)
+    @patch("commands.ota_client._download_package_blob", return_value=(True, None))
     @patch("commands.ota_client._fetch_archive_manifest")
     def test_download_package_version_matching(self, mock_manifest, mock_blob):
         packages = [
@@ -1462,7 +1851,7 @@ class TestDownload(unittest.TestCase):
                 zf.writestr("release.yaml", "version: 1.5.0\n")
 
             def fake_download(archive_id, pkg_id, name, path, **_kwargs):
-                return True
+                return (True, None)
 
             mock_blob.side_effect = fake_download
 
@@ -1476,7 +1865,7 @@ class TestDownload(unittest.TestCase):
 
     @patch("commands.ota_client._queue_snapshot_report")
     @patch("commands.ota_client.get_install_session_id", return_value="session-1")
-    @patch("commands.ota_client._download_package_blob", return_value=True)
+    @patch("commands.ota_client._download_package_blob", return_value=(True, None))
     @patch("commands.ota_client._fetch_archive_manifest")
     def test_download_package_defers_snapshot_report(
         self, mock_manifest, mock_blob, _session_id, mock_queue
@@ -1591,9 +1980,15 @@ class TestDownload(unittest.TestCase):
             )
         self.assertIsNone(result)
 
+    # Without this the test reaches the real OTA endpoint; the assertion is
+    # about tag resolution, not about downloading anything.
+    @patch(
+        "commands.ota_client._download_package_blob",
+        return_value=(False, "network"),
+    )
     @patch("commands.ota_client._fetch_archive_by_tag")
     def test_download_package_falls_back_to_stable_when_requested_tag_missing(
-        self, mock_fetch_by_tag
+        self, mock_fetch_by_tag, _mock_blob
     ):
         # latest → None; stable → valid manifest. Expect both tags queried
         # before the package lookup runs against the stable manifest.
@@ -1639,9 +2034,11 @@ class TestDownload(unittest.TestCase):
             "commands.ota_client.requests.get",
             return_value=_mock_response(iter_content=[b"abc"], headers=headers),
         ), patch(
+            "commands.ota_client.time.sleep"
+        ), patch(
             "builtins.print"
         ) as mock_print:
-            ok = ota._download_package_blob(
+            ok, _code = ota._download_package_blob(
                 "arch-1",
                 "pkg-1",
                 "mypkg",
@@ -1669,7 +2066,7 @@ class TestDownload(unittest.TestCase):
 
         self.assertFalse(ok)
         self.assertTrue(
-            any("content hash mismatch" in str(c) for c in mock_print.call_args_list)
+            any("hash_mismatch" in str(c) for c in mock_print.call_args_list)
         )
 
     def test_robot_download_verifies_against_etag_when_no_explicit_header(self):
@@ -2049,7 +2446,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
 
     @patch("commands.ota_client.report_software_snapshot", return_value=True)
     @patch("commands.ota_client.get_install_session_id", return_value="session-1")
-    @patch("commands.ota_client._download_package_blob", return_value=True)
+    @patch("commands.ota_client._download_package_blob", return_value=(True, None))
     @patch("commands.ota_client._fetch_archive_manifest")
     def test_download_all_from_archive(
         self, mock_manifest, mock_blob, _session_id, mock_report_snapshot

--- a/test_ota.py
+++ b/test_ota.py
@@ -851,6 +851,50 @@ class TestDownloadErrorClassification(unittest.TestCase):
         self.assertFalse(ota.is_retryable_error_code("unknown"))
 
 
+class TestMalformedReleaseYaml(unittest.TestCase):
+    """A package's release.yaml is attacker- or accident-supplied content."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.download = Path(self._tmp.name) / "pkg.zip"
+        self.install_dir = Path(self._tmp.name) / "installed"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _extract_with_release_yaml(self, content):
+        with zipfile.ZipFile(self.download, "w") as zf:
+            zf.writestr("release.yaml", content)
+        return ota._extract_and_read_deps(
+            self.download, self.install_dir, "pkg1", "1.0.0"
+        )
+
+    def test_scalar_release_yaml_does_not_crash_the_install(self):
+        """yaml.safe_load returns a str here; `or {}` does not catch it."""
+        result = self._extract_with_release_yaml("just-a-string\n")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["dependencies"], [])
+
+    def test_list_release_yaml_does_not_crash_the_install(self):
+        result = self._extract_with_release_yaml("- a\n- b\n")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["dependencies"], [])
+
+    def test_non_list_dependencies_is_ignored(self):
+        result = self._extract_with_release_yaml("dependencies: oops\n")
+
+        self.assertEqual(result["dependencies"], [])
+
+    def test_well_formed_release_yaml_still_works(self):
+        result = self._extract_with_release_yaml(
+            "version: 1.0.0\ndependencies:\n  - depA\n"
+        )
+
+        self.assertEqual(result["dependencies"], ["depA"])
+
+
 class TestInstallEventQueue(unittest.TestCase):
     """On-disk install-event queue: buffering, replay safety, ordering.
 

--- a/test_ota.py
+++ b/test_ota.py
@@ -35,11 +35,16 @@ from commands import globals as g
 
 
 def _mock_response(
-    status_code=200, json_data=None, raise_for_status=None, iter_content=None
+    status_code=200,
+    json_data=None,
+    raise_for_status=None,
+    iter_content=None,
+    headers=None,
 ):
     """Build a MagicMock that behaves like a requests.Response."""
     resp = MagicMock()
     resp.status_code = status_code
+    resp.headers = {} if headers is None else headers
     resp.json.return_value = json_data or {}
     if raise_for_status:
         resp.raise_for_status.side_effect = raise_for_status
@@ -112,10 +117,12 @@ class TestConfiguration(unittest.TestCase):
         g.script_directory = self._tmpdir.name
         ota._robot_api_key_cache.clear()
         ota._robot_auth_warning_keys.clear()
+        ota._local_config_cache.clear()
 
     def tearDown(self):
         ota._robot_api_key_cache.clear()
         ota._robot_auth_warning_keys.clear()
+        ota._local_config_cache.clear()
         g.script_directory = self._orig_script_directory
         self._tmpdir.cleanup()
 
@@ -219,6 +226,44 @@ class TestConfiguration(unittest.TestCase):
                     self.assertEqual(saved_path.stat().st_mode & 0o777, 0o600)
                 self.assertEqual(ota.get_robot_api_key(), "robot-key")
                 self.assertEqual(ota._robot_api_key_cache[key_path][1], "robot-key")
+
+    def test_missing_pinned_robot_api_key_file_warns(self):
+        """An explicitly pinned path that yields nothing must not fail quietly."""
+        missing = Path(self._tmpdir.name) / "no-such-key"
+        with patch.dict(
+            os.environ,
+            {"RAISIN_ROBOT_API_KEY_FILE": str(missing)},
+            clear=True,
+        ), patch("builtins.print") as mock_print:
+            self.assertIsNone(ota.get_robot_api_key())
+
+        self.assertTrue(
+            any(
+                "RAISIN_ROBOT_API_KEY_FILE points at" in str(c)
+                for c in mock_print.call_args_list
+            )
+        )
+
+    def test_local_config_is_parsed_once_per_file_revision(self):
+        """Auth headers are rebuilt per package; re-parsing YAML each time is waste."""
+        config_path = Path(g.script_directory) / "configuration_setting.yaml"
+        config_path.write_text(
+            "robot:\n  api_key: cfg-key\n  node: primary\n", encoding="utf-8"
+        )
+
+        with patch.dict(os.environ, {}, clear=True):
+            first = ota._load_local_config()
+            for _ in range(4):
+                ota._load_local_config()
+            self.assertEqual(first.get("robot", {}).get("api_key"), "cfg-key")
+            self.assertEqual(len(ota._local_config_cache), 1)
+
+            # A rewrite must invalidate the cache rather than serve stale values.
+            os.utime(config_path, (0, 0))
+            config_path.write_text(
+                "robot:\n  api_key: rotated-key\n  node: primary\n", encoding="utf-8"
+            )
+            self.assertEqual(ota.get_robot_api_key(), "rotated-key")
 
     @unittest.skipIf(os.name != "posix", "POSIX file permission check")
     def test_insecure_robot_api_key_file_is_ignored(self):
@@ -736,6 +781,7 @@ class TestDownload(unittest.TestCase):
         ota._robot_api_key_cache.clear()
         ota._pending_snapshot_reports.clear()
         ota._robot_auth_warning_keys.clear()
+        ota._local_config_cache.clear()
         self._orig_os_type = g.os_type
         self._orig_os_version = g.os_version
         self._orig_architecture = g.architecture
@@ -753,6 +799,7 @@ class TestDownload(unittest.TestCase):
         ota._install_session_id = None
         ota._pending_snapshot_reports.clear()
         ota._robot_auth_warning_keys.clear()
+        ota._local_config_cache.clear()
         g.os_type = self._orig_os_type
         g.os_version = self._orig_os_version
         g.architecture = self._orig_architecture
@@ -1496,6 +1543,7 @@ class TestDownload(unittest.TestCase):
             platform_str="linux-22.04-x86_64",
             build_type="release",
             install_session_id="session-1",
+            manifest_hashes={},
         )
         self.assertEqual(ota._pending_snapshot_reports, {})
 
@@ -1567,6 +1615,306 @@ class TestDownload(unittest.TestCase):
         called_tags = [call.args[2] for call in mock_fetch_by_tag.call_args_list]
         self.assertEqual(called_tags, ["latest", "stable"])
 
+    # ------------------------------------------------------------------
+    # Robot download integrity
+    # ------------------------------------------------------------------
+
+    # The body the mocked robot download streams, and the digest the server
+    # would advertise for it.
+    _ABC_SHA256 = hashlib.sha256(b"abc").hexdigest()
+
+    def _robot_download(self, headers, target):
+        """Run a robot-authenticated download of b'abc' with the given headers."""
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                "RAISIN_ROBOT_NODE": "jetson",
+            },
+            clear=True,
+        ), patch(
+            "commands.ota_client.get_ota_endpoint",
+            return_value="https://ota.example.com",
+        ), patch(
+            "commands.ota_client.requests.get",
+            return_value=_mock_response(iter_content=[b"abc"], headers=headers),
+        ), patch(
+            "builtins.print"
+        ) as mock_print:
+            ok = ota._download_package_blob(
+                "arch-1",
+                "pkg-1",
+                "mypkg",
+                target,
+                archive_name="dso",
+                archive_version="1.0.3",
+                platform_str="ubuntu-24.04-arm64",
+                install_session_id="session-1",
+            )
+        return ok, mock_print
+
+    def test_robot_download_accepts_matching_content_hash(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "pkg.zip"
+            ok, _ = self._robot_download({"X-Content-Hash": self._ABC_SHA256}, target)
+
+        self.assertTrue(ok)
+
+    def test_robot_download_rejects_content_hash_mismatch(self):
+        """A truncated or corrupted body must fail here, not during extraction."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "pkg.zip"
+            ok, mock_print = self._robot_download({"X-Content-Hash": "f" * 64}, target)
+            self.assertFalse(target.exists())
+
+        self.assertFalse(ok)
+        self.assertTrue(
+            any("content hash mismatch" in str(c) for c in mock_print.call_args_list)
+        )
+
+    def test_robot_download_verifies_against_etag_when_no_explicit_header(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "pkg.zip"
+            ok, _ = self._robot_download({"ETag": f'"{self._ABC_SHA256}"'}, target)
+
+        self.assertTrue(ok)
+
+    def test_robot_download_warns_when_server_sends_no_hash(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "pkg.zip"
+            ok, mock_print = self._robot_download({}, target)
+
+        self.assertTrue(ok)
+        self.assertTrue(
+            any(
+                "integrity was not verified" in str(c)
+                for c in mock_print.call_args_list
+            )
+        )
+
+    def test_expected_content_hash_normalizes_server_formats(self):
+        self.assertEqual(
+            ota._expected_content_hash({"X-Content-Hash": self._ABC_SHA256.upper()}),
+            self._ABC_SHA256,
+        )
+        self.assertEqual(
+            ota._expected_content_hash({"ETag": f'W/"sha256:{self._ABC_SHA256}"'}),
+            self._ABC_SHA256,
+        )
+        self.assertIsNone(ota._expected_content_hash({"ETag": "not-a-hash"}))
+        self.assertIsNone(ota._expected_content_hash({}))
+
+    # ------------------------------------------------------------------
+    # Snapshot manifest-hash backfill
+    # ------------------------------------------------------------------
+
+    def _write_install_metadata(self, base, package_name, package_id, manifest_hash):
+        install_dir = base / package_name / "linux" / "22.04" / "x86_64" / "release"
+        install_dir.mkdir(parents=True, exist_ok=True)
+        metadata = {
+            "source": "archive",
+            "archiveId": "arch-1",
+            "platform": "linux-22.04-x86_64",
+            "buildType": "release",
+            "packageName": package_name,
+            "packageId": package_id,
+            "packageVersion": "1.0.0",
+        }
+        if manifest_hash:
+            metadata["manifestHash"] = manifest_hash
+        (install_dir / "ota-install.json").write_text(
+            json.dumps(metadata), encoding="utf-8"
+        )
+
+    def test_snapshot_backfills_manifest_hash_from_archive_manifest(self):
+        """Installs recorded before manifestHash existed must still be reported.
+
+        The server clears and replaces the node's package set on every
+        snapshot, so omitting a package records it as uninstalled.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            self._write_install_metadata(base, "pkg1", "p1", "a" * 64)
+            self._write_install_metadata(base, "pkg2", "p2", None)
+
+            hashes = ota.manifest_hashes_by_package_id(
+                [
+                    {"packageId": "p1", "manifestHash": "a" * 64},
+                    {"packageId": "p2", "manifestHash": "b" * 64},
+                ]
+            )
+            packages = ota._collect_archive_snapshot_packages(
+                base, "arch-1", "linux-22.04-x86_64", "release", manifest_hashes=hashes
+            )
+
+        self.assertCountEqual(
+            packages,
+            [
+                {
+                    "packageId": "p1",
+                    "packageName": "pkg1",
+                    "version": "1.0.0",
+                    "manifestHash": "a" * 64,
+                },
+                {
+                    "packageId": "p2",
+                    "packageName": "pkg2",
+                    "version": "1.0.0",
+                    "manifestHash": "b" * 64,
+                },
+            ],
+        )
+
+    def test_snapshot_excludes_unrecoverable_package_with_warning(self):
+        """A package absent from the manifest cannot be reported either way.
+
+        The server rejects customPackages entries whose packageId belongs to
+        the archive manifest, so there is no fallback route — say so instead of
+        dropping it silently.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            self._write_install_metadata(base, "pkg1", "p1", "a" * 64)
+            self._write_install_metadata(base, "ghost", "p9", None)
+
+            with patch("builtins.print") as mock_print:
+                packages = ota._collect_archive_snapshot_packages(
+                    base,
+                    "arch-1",
+                    "linux-22.04-x86_64",
+                    "release",
+                    manifest_hashes={"p1": "a" * 64},
+                )
+
+        self.assertEqual([p["packageName"] for p in packages], ["pkg1"])
+        self.assertTrue(
+            any("Excluding 'ghost" in str(c) for c in mock_print.call_args_list)
+        )
+
+    def test_queued_snapshot_reports_merge_manifest_hashes(self):
+        """Each single-package install contributes its slice of the manifest."""
+        ota._queue_snapshot_report(
+            install_base_path=Path("/tmp/install-base"),
+            archive_id="arch-1",
+            archive_name="dso",
+            archive_version="1.0.3",
+            platform_str="linux-22.04-x86_64",
+            build_type="release",
+            install_session_id="session-1",
+            manifest_hashes={"p1": "a" * 64},
+        )
+        ota._queue_snapshot_report(
+            install_base_path=Path("/tmp/install-base"),
+            archive_id="arch-1",
+            archive_name="dso",
+            archive_version="1.0.3",
+            platform_str="linux-22.04-x86_64",
+            build_type="release",
+            install_session_id="session-1",
+            manifest_hashes={"p2": "b" * 64},
+        )
+
+        pending = list(ota._pending_snapshot_reports.values())
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(
+            pending[0]["manifest_hashes"], {"p1": "a" * 64, "p2": "b" * 64}
+        )
+
+    # ------------------------------------------------------------------
+    # Desired state
+    # ------------------------------------------------------------------
+
+    def _desired_state(self, payload, platform="ubuntu-24.04-arm64"):
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                "RAISIN_ROBOT_NODE": "jetson",
+            },
+            clear=True,
+        ), patch(
+            "commands.ota_client.get_ota_endpoint",
+            return_value="https://ota.example.com",
+        ), patch(
+            "commands.ota_client.requests.get",
+            return_value=_mock_response(json_data={"success": True, "data": payload}),
+        ), patch(
+            "builtins.print"
+        ):
+            return ota._resolve_desired_state(platform)
+
+    def test_resolve_desired_state_returns_assigned_target(self):
+        halted, name, version = self._desired_state(
+            {
+                "halt": False,
+                "reason": "node_pin",
+                "target": {
+                    "archiveId": "arch-1",
+                    "name": "raisin-robot",
+                    "version": "2026.1.0",
+                    "platform": "ubuntu-24.04-arm64",
+                },
+            }
+        )
+
+        self.assertEqual((halted, name, version), (False, "raisin-robot", "2026.1.0"))
+
+    def test_resolve_desired_state_honours_halt(self):
+        halted, name, version = self._desired_state(
+            {"halt": True, "haltSources": ["tenant"], "reason": "node_pin"}
+        )
+
+        self.assertEqual((halted, name, version), (True, None, None))
+
+    def test_resolve_desired_state_ignores_target_for_other_platform(self):
+        halted, name, _ = self._desired_state(
+            {
+                "halt": False,
+                "reason": "node_pin",
+                "target": {
+                    "name": "raisin-robot",
+                    "version": "2026.1.0",
+                    "platform": "ubuntu-22.04-x86_64",
+                },
+            }
+        )
+
+        self.assertFalse(halted)
+        self.assertIsNone(name)
+
+    def test_resolve_desired_state_without_robot_auth_is_inert(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                ota._resolve_desired_state("ubuntu-24.04-arm64"), (False, None, None)
+            )
+
+    @patch("commands.ota_client._fetch_archive_with_stable_fallback")
+    @patch("commands.ota_client._resolve_desired_state")
+    def test_download_all_from_archive_aborts_when_halted(
+        self, mock_desired, mock_fetch
+    ):
+        mock_desired.return_value = (True, None, None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = ota.download_all_from_archive("release", Path(tmpdir))
+
+        self.assertEqual(result, {})
+        mock_fetch.assert_not_called()
+
+    @patch("commands.ota_client._fetch_archive_manifest", return_value=None)
+    @patch("commands.ota_client._resolve_desired_state")
+    def test_caller_pinned_archive_outranks_desired_state(
+        self, mock_desired, mock_fetch
+    ):
+        """An explicit pin is a deliberate choice; the fleet must not override it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ota.download_all_from_archive(
+                "release", Path(tmpdir), archive_version="1.2.3"
+            )
+
+        mock_desired.assert_not_called()
+        self.assertEqual(mock_fetch.call_args.args[2], "1.2.3")
+
 
 class TestArchiveNameAndTimestamp(unittest.TestCase):
     """Test archive name derivation and timestamp-based downloads."""
@@ -1578,6 +1926,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         ota._install_session_id = None
         ota._robot_api_key_cache.clear()
         ota._robot_auth_warning_keys.clear()
+        ota._local_config_cache.clear()
         self._orig_os_type = g.os_type
         self._orig_os_version = g.os_version
         self._orig_architecture = g.architecture
@@ -1596,6 +1945,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         ota._pending_snapshot_reports.clear()
         ota._robot_api_key_cache.clear()
         ota._robot_auth_warning_keys.clear()
+        ota._local_config_cache.clear()
         g.os_type = self._orig_os_type
         g.os_version = self._orig_os_version
         g.architecture = self._orig_architecture

--- a/test_ota.py
+++ b/test_ota.py
@@ -63,6 +63,22 @@ def _mock_response(
     return resp
 
 
+def _sync_ota_context():
+    """Point the OTA core at whatever the CLI globals currently hold.
+
+    Production wires this once in `init_environment`; tests move the globals
+    around per case, so they re-sync after each change.
+    """
+    ota.configure(
+        ota.OtaContext(
+            workspace=Path(g.script_directory or "."),
+            os_type=g.os_type,
+            os_version=g.os_version,
+            architecture=g.architecture,
+        )
+    )
+
+
 def _as_robot(testcase):
     """Give a test the robot identity that install-event recording requires.
 
@@ -137,6 +153,7 @@ class TestConfiguration(unittest.TestCase):
         self._tmpdir = tempfile.TemporaryDirectory()
         self._orig_script_directory = g.script_directory
         g.script_directory = self._tmpdir.name
+        _sync_ota_context()
         ota._robot_api_key_cache.clear()
         ota._robot_auth_warning_keys.clear()
         ota._local_config_cache.clear()
@@ -146,6 +163,7 @@ class TestConfiguration(unittest.TestCase):
         ota._robot_auth_warning_keys.clear()
         ota._local_config_cache.clear()
         g.script_directory = self._orig_script_directory
+        _sync_ota_context()
         self._tmpdir.cleanup()
 
     def test_get_ota_endpoint_returns_default_when_unset(self):
@@ -343,11 +361,13 @@ class TestTokenPersistence(unittest.TestCase):
         self._tmpdir = tempfile.mkdtemp()
         self._orig_script_directory = g.script_directory
         g.script_directory = self._tmpdir
+        _sync_ota_context()
 
     def tearDown(self):
         ota._cached_token = None
         ota._auth_failed = False
         g.script_directory = self._orig_script_directory
+        _sync_ota_context()
         import shutil
 
         shutil.rmtree(self._tmpdir, ignore_errors=True)
@@ -653,15 +673,21 @@ class TestUpload(unittest.TestCase):
         self._orig_os_version = g.os_version
         self._orig_architecture = g.architecture
         g.os_type = "linux"
+        _sync_ota_context()
         g.os_version = "22.04"
+        _sync_ota_context()
         g.architecture = "x86_64"
+        _sync_ota_context()
 
     def tearDown(self):
         ota._cached_token = None
         ota._auth_failed = False
         g.os_type = self._orig_os_type
+        _sync_ota_context()
         g.os_version = self._orig_os_version
+        _sync_ota_context()
         g.architecture = self._orig_architecture
+        _sync_ota_context()
 
     def test_compute_sha256_correct(self):
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
@@ -906,6 +932,7 @@ class TestInstallEventQueue(unittest.TestCase):
         self._tmp = tempfile.TemporaryDirectory()
         self._orig_script_directory = g.script_directory
         g.script_directory = self._tmp.name
+        _sync_ota_context()
         ota._install_session_id = "session-29"
         ota.clear_pending_install_failure()
         _as_robot(self)
@@ -914,6 +941,7 @@ class TestInstallEventQueue(unittest.TestCase):
         ota._install_session_id = None
         ota.clear_pending_install_failure()
         g.script_directory = self._orig_script_directory
+        _sync_ota_context()
         self._tmp.cleanup()
 
     def _queued(self):
@@ -1164,7 +1192,9 @@ class TestInstallEventEmission(unittest.TestCase):
             g.architecture,
         )
         g.script_directory = self._tmp.name
+        _sync_ota_context()
         g.os_type, g.os_version, g.architecture = "linux", "22.04", "x86_64"
+        _sync_ota_context()
         ota._install_session_id = "session-emit"
         ota._archive_cache.clear()
         ota.clear_pending_install_failure()
@@ -1340,7 +1370,9 @@ class TestTransactionalArchiveInstall(unittest.TestCase):
         self._tmp = tempfile.TemporaryDirectory()
         self._orig = (g.script_directory, g.os_type, g.os_version, g.architecture)
         g.script_directory = self._tmp.name
+        _sync_ota_context()
         g.os_type, g.os_version, g.architecture = "linux", "22.04", "x86_64"
+        _sync_ota_context()
         ota._install_session_id = "session-tx"
         ota._archive_cache.clear()
         ota.clear_pending_install_failure()
@@ -1560,11 +1592,13 @@ class TestInstallSessionPersistence(unittest.TestCase):
         self._tmp = tempfile.TemporaryDirectory()
         self._orig_script_directory = g.script_directory
         g.script_directory = self._tmp.name
+        _sync_ota_context()
         ota._install_session_id = None
 
     def tearDown(self):
         ota._install_session_id = None
         g.script_directory = self._orig_script_directory
+        _sync_ota_context()
         self._tmp.cleanup()
 
     def _new_process(self):
@@ -1930,9 +1964,13 @@ class TestDownload(unittest.TestCase):
         self._orig_script_directory = g.script_directory
         self._tmp_script_dir = tempfile.TemporaryDirectory()
         g.os_type = "linux"
+        _sync_ota_context()
         g.os_version = "22.04"
+        _sync_ota_context()
         g.architecture = "x86_64"
+        _sync_ota_context()
         g.script_directory = self._tmp_script_dir.name
+        _sync_ota_context()
 
     def tearDown(self):
         ota._cached_token = None
@@ -1943,9 +1981,13 @@ class TestDownload(unittest.TestCase):
         ota._robot_auth_warning_keys.clear()
         ota._local_config_cache.clear()
         g.os_type = self._orig_os_type
+        _sync_ota_context()
         g.os_version = self._orig_os_version
+        _sync_ota_context()
         g.architecture = self._orig_architecture
+        _sync_ota_context()
         g.script_directory = self._orig_script_directory
+        _sync_ota_context()
         self._tmp_script_dir.cleanup()
 
     @patch("commands.ota_client.authenticate", return_value="tok")
@@ -2528,6 +2570,7 @@ class TestDownload(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             install_base = Path(tmpdir) / "release" / "install"
             install_base.mkdir(parents=True)
 
@@ -2602,6 +2645,7 @@ class TestDownload(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             install_base = Path(tmpdir) / "release" / "install"
             install_base.mkdir(parents=True)
 
@@ -2642,6 +2686,7 @@ class TestDownload(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             install_base = Path(tmpdir) / "release" / "install"
             install_base.mkdir(parents=True)
             download_file = Path(tmpdir) / "install" / "mypkg-ota-1.2.0.zip"
@@ -2710,6 +2755,7 @@ class TestDownload(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             install_base = Path(tmpdir) / "release" / "install"
             install_base.mkdir(parents=True)
 
@@ -2723,6 +2769,7 @@ class TestDownload(unittest.TestCase):
     def test_download_package_manifest_unavailable(self, _manifest):
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             result = ota.download_package(
                 "mypkg", "", "release", Path(tmpdir), tag=None
             )
@@ -2735,6 +2782,7 @@ class TestDownload(unittest.TestCase):
         # per-target loop will then fall back to GitHub releases.
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             result = ota.download_package(
                 "mypkg", "", "release", Path(tmpdir), tag="stable"
             )
@@ -2765,6 +2813,7 @@ class TestDownload(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             ota.download_package("mypkg", "", "release", Path(tmpdir), tag="latest")
 
         called_tags = [call.args[2] for call in mock_fetch_by_tag.call_args_list]
@@ -3079,6 +3128,7 @@ class TestDownload(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             live = Path(tmpdir) / "release" / "install"
             live.parent.mkdir(parents=True, exist_ok=True)
             results = ota.download_all_from_archive("release", live)
@@ -3224,9 +3274,13 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         self._orig_script_directory = g.script_directory
         self._tmp_script_dir = tempfile.TemporaryDirectory()
         g.os_type = "linux"
+        _sync_ota_context()
         g.os_version = "22.04"
+        _sync_ota_context()
         g.architecture = "x86_64"
+        _sync_ota_context()
         g.script_directory = self._tmp_script_dir.name
+        _sync_ota_context()
 
     def tearDown(self):
         ota._cached_token = None
@@ -3238,9 +3292,13 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         ota._robot_auth_warning_keys.clear()
         ota._local_config_cache.clear()
         g.os_type = self._orig_os_type
+        _sync_ota_context()
         g.os_version = self._orig_os_version
+        _sync_ota_context()
         g.architecture = self._orig_architecture
+        _sync_ota_context()
         g.script_directory = self._orig_script_directory
+        _sync_ota_context()
         self._tmp_script_dir.cleanup()
         # Clear env var if set
         if "RAISIN_ARCHIVE_NAME" in os.environ:
@@ -3302,6 +3360,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             install_base = Path(tmpdir) / "release" / "install"
             install_base.mkdir(parents=True)
 
@@ -3364,6 +3423,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             install_base = Path(tmpdir) / "release" / "install"
             install_base.mkdir(parents=True)
 
@@ -3435,6 +3495,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
     def test_download_package_uses_archive_name_override(self, mock_manifest):
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             install_base = Path(tmpdir) / "release" / "install"
             install_base.mkdir(parents=True)
 
@@ -3460,6 +3521,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
     def test_download_all_from_archive_uses_archive_name_override(self, mock_manifest):
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             install_base = Path(tmpdir) / "release" / "install"
             install_base.mkdir(parents=True)
 
@@ -3485,6 +3547,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             install_base = Path(tmpdir) / "release" / "install"
             install_base.mkdir(parents=True)
 
@@ -3556,6 +3619,7 @@ class TestInstallOutcomeDecision(unittest.TestCase):
         self._tmp = tempfile.TemporaryDirectory()
         self._orig = g.script_directory
         g.script_directory = self._tmp.name
+        _sync_ota_context()
         ota._install_session_id = "session-outcome"
         ota.clear_pending_install_failure()
         _as_robot(self)
@@ -3564,6 +3628,7 @@ class TestInstallOutcomeDecision(unittest.TestCase):
         ota._install_session_id = None
         ota.clear_pending_install_failure()
         g.script_directory = self._orig
+        _sync_ota_context()
         self._tmp.cleanup()
 
     def _events(self):
@@ -3720,6 +3785,7 @@ class TestInstallIntegration(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             self._orig_script_directory = g.script_directory
             g.script_directory = tmpdir
+            _sync_ota_context()
             try:
                 with patch(
                     "commands.install.load_configuration",
@@ -3729,6 +3795,7 @@ class TestInstallIntegration(unittest.TestCase):
                         install_command([], "release", tag="none")
             finally:
                 g.script_directory = self._orig_script_directory
+                _sync_ota_context()
 
         self.assertIsNone(mock_dl.call_args.kwargs["tag"])
 
@@ -3756,6 +3823,7 @@ class TestInstallIntegration(unittest.TestCase):
         self._orig_script_directory = g.script_directory
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             try:
                 with patch(
                     "commands.install.load_configuration",
@@ -3772,6 +3840,7 @@ class TestInstallIntegration(unittest.TestCase):
                 return mock_dl.call_args.kwargs["tag"]
             finally:
                 g.script_directory = self._orig_script_directory
+                _sync_ota_context()
 
     def test_install_command_defaults_to_latest_for_devel_user(self):
         self.assertEqual(self._run_install_command_with_user_type("devel"), "latest")
@@ -3816,6 +3885,7 @@ class TestPublishIntegration(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             g.script_directory = tmpdir
+            _sync_ota_context()
             target_dir = Path(tmpdir) / "src" / "mypkg"
             target_dir.mkdir(parents=True)
             release_yaml = target_dir / "release.yaml"

--- a/test_ota.py
+++ b/test_ota.py
@@ -142,6 +142,43 @@ class TestConfiguration(unittest.TestCase):
                 result = ota.get_ssh_key_path()
                 self.assertEqual(result.name, "id_ed25519")
 
+    def test_get_robot_api_key_from_env(self):
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": " robot-key ",  # pragma: allowlist secret
+            },
+            clear=True,
+        ):
+            self.assertEqual(ota.get_robot_api_key(), "robot-key")
+
+    def test_save_and_read_robot_api_key_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            key_path = Path(tmpdir) / "robot-api-key"
+            with patch.dict(
+                os.environ,
+                {"RAISIN_ROBOT_API_KEY_FILE": str(key_path)},
+                clear=True,
+            ):
+                saved_path = ota.save_robot_api_key(" robot-key ")
+                self.assertEqual(saved_path, key_path)
+                if os.name == "posix":
+                    self.assertEqual(saved_path.stat().st_mode & 0o777, 0o600)
+                self.assertEqual(ota.get_robot_api_key(), "robot-key")
+
+    @unittest.skipIf(os.name != "posix", "POSIX file permission check")
+    def test_insecure_robot_api_key_file_is_ignored(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            key_path = Path(tmpdir) / "robot-api-key"
+            key_path.write_text("robot-key\n", encoding="utf-8")
+            os.chmod(key_path, 0o644)
+            with patch.dict(
+                os.environ,
+                {"RAISIN_ROBOT_API_KEY_FILE": str(key_path)},
+                clear=True,
+            ):
+                self.assertIsNone(ota.get_robot_api_key())
+
 
 # ============================================================================
 # 1b. Token Persistence Tests
@@ -625,6 +662,7 @@ class TestDownload(unittest.TestCase):
         ota._cached_token = None
         ota._auth_failed = False
         ota._archive_cache.clear()
+        ota._install_session_id = None
         self._orig_os_type = g.os_type
         self._orig_os_version = g.os_version
         self._orig_architecture = g.architecture
@@ -637,6 +675,7 @@ class TestDownload(unittest.TestCase):
         ota._cached_token = None
         ota._auth_failed = False
         ota._archive_cache.clear()
+        ota._install_session_id = None
         g.os_type = self._orig_os_type
         g.os_version = self._orig_os_version
         g.architecture = self._orig_architecture
@@ -904,6 +943,134 @@ class TestDownload(unittest.TestCase):
         )
         self.assertIsNone(result)
 
+    @patch(
+        "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
+    )
+    @patch("commands.ota_client.requests.get")
+    def test_download_package_blob_uses_robot_endpoint_when_key_configured(
+        self, mock_get, _ep
+    ):
+        mock_get.return_value = _mock_response(iter_content=[b"pkg-data"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            download_path = Path(tmpdir) / "pkg.zip"
+            with patch.dict(
+                os.environ,
+                {
+                    "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                    "RAISIN_OTA_CLIENT_VERSION": "raisin-cli-test",
+                },
+                clear=True,
+            ):
+                result = ota._download_package_blob(
+                    "arch-1",
+                    "pkg-1",
+                    "mypkg",
+                    download_path,
+                    archive_name="dso",
+                    archive_version="v1.0.3",
+                    platform_str="ubuntu-24.04-arm64",
+                    install_session_id="session-1",
+                )
+
+            self.assertTrue(result)
+            self.assertEqual(download_path.read_bytes(), b"pkg-data")
+
+        call_args = mock_get.call_args
+        self.assertEqual(
+            call_args.args[0],
+            "https://ota.example.com/robots/me/archives/by-key/"
+            "packages/pkg-1/download",
+        )
+        self.assertEqual(
+            call_args.kwargs["params"],
+            {
+                "name": "dso",
+                "platform": "ubuntu-24.04-arm64",
+                "version": "1.0.3",
+            },
+        )
+        self.assertEqual(
+            call_args.kwargs["headers"]["Authorization"], "Robot robot-key"
+        )
+        self.assertEqual(
+            call_args.kwargs["headers"]["X-Client-Version"], "raisin-cli-test"
+        )
+        self.assertEqual(
+            call_args.kwargs["headers"]["X-Install-Session-Id"], "session-1"
+        )
+
+    @patch("commands.ota_client._stream_download", return_value=True)
+    @patch(
+        "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
+    )
+    def test_download_package_blob_keeps_legacy_path_without_robot_key(
+        self, _ep, mock_stream
+    ):
+        with patch.dict(os.environ, {}, clear=True):
+            result = ota._download_package_blob(
+                "arch-1",
+                "pkg-1",
+                "mypkg",
+                Path("/tmp/pkg.zip"),
+                archive_name="dso",
+                archive_version="1.0.3",
+                platform_str="ubuntu-24.04-arm64",
+                install_session_id="session-1",
+            )
+
+        self.assertTrue(result)
+        mock_stream.assert_called_once_with(
+            "https://ota.example.com/archives/arch-1/packages/pkg-1/download",
+            Path("/tmp/pkg.zip"),
+            "mypkg",
+        )
+
+    @patch(
+        "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
+    )
+    @patch("commands.ota_client.requests.post")
+    def test_report_software_snapshot_posts_robot_payload(self, mock_post, _ep):
+        mock_post.return_value = _mock_response()
+        packages = [{"packageId": "pkg-1", "packageName": "mypkg", "version": "1.2.0"}]
+
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                "RAISIN_CLIENT_VERSION": "raisin-cli-test",
+            },
+            clear=True,
+        ):
+            result = ota.report_software_snapshot(
+                archive_id="arch-1",
+                archive_name="dso",
+                archive_version="v1.0.3",
+                platform_str="ubuntu-24.04-arm64",
+                packages=packages,
+                install_session_id="session-1",
+            )
+
+        self.assertTrue(result)
+        call_args = mock_post.call_args
+        self.assertEqual(
+            call_args.args[0],
+            "https://ota.example.com/robots/me/software-snapshot",
+        )
+        self.assertEqual(
+            call_args.kwargs["headers"]["Authorization"], "Robot robot-key"
+        )
+        self.assertEqual(
+            call_args.kwargs["headers"]["X-Install-Session-Id"], "session-1"
+        )
+        self.assertEqual(call_args.kwargs["json"]["archiveId"], "arch-1")
+        self.assertEqual(call_args.kwargs["json"]["name"], "dso")
+        self.assertEqual(call_args.kwargs["json"]["version"], "1.0.3")
+        self.assertEqual(call_args.kwargs["json"]["platform"], "ubuntu-24.04-arm64")
+        self.assertEqual(call_args.kwargs["json"]["packages"], packages)
+        self.assertEqual(call_args.kwargs["json"]["installSessionId"], "session-1")
+        self.assertEqual(call_args.kwargs["json"]["clientVersion"], "raisin-cli-test")
+
     @patch("commands.ota_client._fetch_archive_by_tag")
     @patch("commands.ota_client._download_package_blob")
     def test_download_all_uses_tag_when_provided(self, mock_dl, mock_fetch_by_tag):
@@ -1013,7 +1180,7 @@ class TestDownload(unittest.TestCase):
                 zf.writestr("release.yaml", "version: 1.2.0\ndependencies:\n  - depA\n")
 
             # Make _download_package_blob write the zip to disk (already done)
-            def fake_download(archive_id, pkg_id, name, path):
+            def fake_download(archive_id, pkg_id, name, path, **_kwargs):
                 # File already written above
                 return True
 
@@ -1083,7 +1250,7 @@ class TestDownload(unittest.TestCase):
             with zipfile.ZipFile(download_file, "w") as zf:
                 zf.writestr("release.yaml", "version: 1.5.0\n")
 
-            def fake_download(archive_id, pkg_id, name, path):
+            def fake_download(archive_id, pkg_id, name, path, **_kwargs):
                 return True
 
             mock_blob.side_effect = fake_download
@@ -1172,6 +1339,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         ota._cached_token = None
         ota._auth_failed = False
         ota._archive_cache.clear()
+        ota._install_session_id = None
         self._orig_os_type = g.os_type
         self._orig_os_version = g.os_version
         self._orig_architecture = g.architecture
@@ -1184,6 +1352,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         ota._cached_token = None
         ota._auth_failed = False
         ota._archive_cache.clear()
+        ota._install_session_id = None
         g.os_type = self._orig_os_type
         g.os_version = self._orig_os_version
         g.architecture = self._orig_architecture
@@ -1284,9 +1453,13 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         self.assertEqual(metadata["blobHash"], "abc123" * 10 + "abcd")
         self.assertIn("installedAt", metadata)
 
+    @patch("commands.ota_client.report_software_snapshot", return_value=True)
+    @patch("commands.ota_client.get_install_session_id", return_value="session-1")
     @patch("commands.ota_client._download_package_blob", return_value=True)
     @patch("commands.ota_client._fetch_archive_manifest")
-    def test_download_all_from_archive(self, mock_manifest, mock_blob):
+    def test_download_all_from_archive(
+        self, mock_manifest, mock_blob, _session_id, mock_report_snapshot
+    ):
         """Download all packages from an archive."""
         packages = [
             {
@@ -1342,6 +1515,23 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         self.assertEqual(metadata["archiveVersion"], "v2024.01")
         self.assertEqual(metadata["packageId"], "p1")
         self.assertEqual(metadata["manifestHash"], "a" * 64)
+        self.assertEqual(metadata["installSessionId"], "session-1")
+        self.assertEqual(result["pkg1"]["otaMetadata"]["installSessionId"], "session-1")
+
+        mock_report_snapshot.assert_called_once()
+        report_kwargs = mock_report_snapshot.call_args.kwargs
+        self.assertEqual(report_kwargs["archive_id"], "arch-1")
+        self.assertEqual(report_kwargs["archive_name"], "raisin-robot")
+        self.assertEqual(report_kwargs["archive_version"], "v2024.01")
+        self.assertEqual(report_kwargs["platform_str"], "linux-22.04-x86_64")
+        self.assertEqual(report_kwargs["install_session_id"], "session-1")
+        self.assertCountEqual(
+            report_kwargs["packages"],
+            [
+                {"packageId": "p1", "packageName": "pkg1", "version": "1.0.0"},
+                {"packageId": "p2", "packageName": "pkg2", "version": "2.0.0"},
+            ],
+        )
 
     @patch(
         "commands.ota_client._fetch_archive_manifest",

--- a/test_ota.py
+++ b/test_ota.py
@@ -63,6 +63,23 @@ def _mock_response(
     return resp
 
 
+def _as_robot(testcase):
+    """Give a test the robot identity that install-event recording requires.
+
+    `raisin_master` also runs on developer workstations, which have none — and
+    there it records nothing at all.
+    """
+    env = patch.dict(
+        os.environ,
+        {
+            "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+            "RAISIN_ROBOT_NODE": "jetson",
+        },
+    )
+    env.start()
+    testcase.addCleanup(env.stop)
+
+
 def _make_sshsig(raw_sig=None):
     """Build a minimal SSHSIG container and return (sshsig_bytes, sig_wire_blob).
 
@@ -847,6 +864,7 @@ class TestInstallEventQueue(unittest.TestCase):
         g.script_directory = self._tmp.name
         ota._install_session_id = "session-29"
         ota.clear_pending_install_failure()
+        _as_robot(self)
 
     def tearDown(self):
         ota._install_session_id = None
@@ -1026,6 +1044,60 @@ class TestInstallEventQueue(unittest.TestCase):
         self.assertEqual(posted, [ota._INSTALL_EVENT_BATCH_LIMIT, 5])
         self.assertEqual(self._queued(), [])
 
+    def test_no_robot_identity_records_nothing(self):
+        """A developer PC has no robot to attribute install events to.
+
+        Buffering them there grows a file that can never be flushed.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(ota.record_install_event("started"))
+            self.assertIsNone(ota.report_install_outcome(True))
+
+        self.assertEqual(self._queued(), [])
+        self.assertFalse(ota._install_event_queue_path().exists())
+
+    def test_api_key_without_a_node_records_nothing(self):
+        """Half-configured is not configured: the reports would be rejected."""
+        with patch.dict(
+            os.environ,
+            {"RAISIN_ROBOT_API_KEY": "robot-key"},  # pragma: allowlist secret
+            clear=True,
+        ), patch("builtins.print"):
+            ota.record_install_event("started")
+
+        self.assertEqual(self._queued(), [])
+
+    def test_queue_is_capped_so_a_long_outage_cannot_grow_it_forever(self):
+        cap = ota._MAX_BUFFERED_INSTALL_EVENTS
+        for i in range(cap + 25):
+            ota._append_install_event({"eventId": f"e{i}", "eventType": "started"})
+
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                "RAISIN_ROBOT_NODE": "jetson",
+            },
+            clear=True,
+        ), patch(
+            "commands.ota_client.get_ota_endpoint",
+            return_value="https://ota.example.com",
+        ), patch(
+            "commands.ota_client.requests.post",
+            side_effect=requests.ConnectionError("offline"),
+        ), patch(
+            "builtins.print"
+        ) as mock_print:
+            ota.flush_install_events()
+
+        remaining = self._queued()
+        self.assertEqual(len(remaining), cap)
+        # The newest events are the ones worth keeping.
+        self.assertEqual(remaining[-1]["eventId"], f"e{cap + 24}")
+        self.assertTrue(
+            any("discard" in str(c).lower() for c in mock_print.call_args_list)
+        )
+
     def test_flush_without_robot_auth_is_a_noop_that_keeps_the_queue(self):
         ota.record_install_event("started")
 
@@ -1052,6 +1124,7 @@ class TestInstallEventEmission(unittest.TestCase):
         ota._install_session_id = "session-emit"
         ota._archive_cache.clear()
         ota.clear_pending_install_failure()
+        _as_robot(self)
 
     def tearDown(self):
         ota._install_session_id = None
@@ -1227,6 +1300,7 @@ class TestTransactionalArchiveInstall(unittest.TestCase):
         ota._install_session_id = "session-tx"
         ota._archive_cache.clear()
         ota.clear_pending_install_failure()
+        _as_robot(self)
         self.release = Path(self._tmp.name) / "release"
         self.release.mkdir(parents=True)
         self.live = self.release / "install"
@@ -3290,6 +3364,7 @@ class TestInstallOutcomeDecision(unittest.TestCase):
         g.script_directory = self._tmp.name
         ota._install_session_id = "session-outcome"
         ota.clear_pending_install_failure()
+        _as_robot(self)
 
     def tearDown(self):
         ota._install_session_id = None

--- a/test_ota.py
+++ b/test_ota.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import base64
+import contextlib
 import errno
 import hashlib
 import json
@@ -30,6 +31,7 @@ from unittest.mock import MagicMock, patch, call
 from click.testing import CliRunner
 
 import commands.ota_client as ota
+import commands.robot_credentials as rc
 from commands import globals as g
 from commands import install_tree
 
@@ -63,6 +65,16 @@ def _mock_response(
     return resp
 
 
+# Identity the core is configured with while a test declares itself a robot.
+_TEST_ROBOT = None
+
+TEST_ROBOT_IDENTITY = ota.RobotIdentity(
+    api_key="robot-key",  # pragma: allowlist secret
+    node_key="jetson",
+    client_version="raisin-cli",
+)
+
+
 def _sync_ota_context():
     """Point the OTA core at whatever the CLI globals currently hold.
 
@@ -75,25 +87,60 @@ def _sync_ota_context():
             os_type=g.os_type,
             os_version=g.os_version,
             architecture=g.architecture,
+            robot=_TEST_ROBOT,
         )
     )
 
 
-def _as_robot(testcase):
-    """Give a test the robot identity that install-event recording requires.
-
-    `raisin_master` also runs on developer workstations, which have none — and
-    there it records nothing at all.
-    """
-    env = patch.dict(
-        os.environ,
-        {
-            "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-            "RAISIN_ROBOT_NODE": "jetson",
-        },
+@contextlib.contextmanager
+def _robot_identity(client_version="raisin-cli"):
+    """Run a block as a configured robot, as `init_environment` would."""
+    global _TEST_ROBOT
+    previous = _TEST_ROBOT
+    _TEST_ROBOT = ota.RobotIdentity(
+        api_key="robot-key",  # pragma: allowlist secret
+        node_key="jetson",
+        client_version=client_version,
     )
-    env.start()
-    testcase.addCleanup(env.stop)
+    _sync_ota_context()
+    try:
+        yield
+    finally:
+        _TEST_ROBOT = previous
+        _sync_ota_context()
+
+
+@contextlib.contextmanager
+def _no_robot_identity():
+    """Run a block as a machine with no robot credential."""
+    global _TEST_ROBOT
+    previous = _TEST_ROBOT
+    _TEST_ROBOT = None
+    _sync_ota_context()
+    try:
+        yield
+    finally:
+        _TEST_ROBOT = previous
+        _sync_ota_context()
+
+
+def _as_robot(testcase, identity=TEST_ROBOT_IDENTITY):
+    """Give a test the robot identity that robot-authenticated calls require.
+
+    The CLI also runs on developer workstations, which have none — and there
+    the core makes no robot requests and records nothing.
+    """
+    global _TEST_ROBOT
+    previous = _TEST_ROBOT
+    _TEST_ROBOT = identity
+    _sync_ota_context()
+
+    def _restore():
+        global _TEST_ROBOT
+        _TEST_ROBOT = previous
+        _sync_ota_context()
+
+    testcase.addCleanup(_restore)
 
 
 def _make_sshsig(raw_sig=None):
@@ -154,14 +201,14 @@ class TestConfiguration(unittest.TestCase):
         self._orig_script_directory = g.script_directory
         g.script_directory = self._tmpdir.name
         _sync_ota_context()
-        ota._robot_api_key_cache.clear()
-        ota._robot_auth_warning_keys.clear()
-        ota._local_config_cache.clear()
+        rc._robot_api_key_cache.clear()
+        rc._robot_auth_warning_keys.clear()
+        rc._local_config_cache.clear()
 
     def tearDown(self):
-        ota._robot_api_key_cache.clear()
-        ota._robot_auth_warning_keys.clear()
-        ota._local_config_cache.clear()
+        rc._robot_api_key_cache.clear()
+        rc._robot_auth_warning_keys.clear()
+        rc._local_config_cache.clear()
         g.script_directory = self._orig_script_directory
         _sync_ota_context()
         self._tmpdir.cleanup()
@@ -210,7 +257,7 @@ class TestConfiguration(unittest.TestCase):
             },
             clear=True,
         ):
-            self.assertEqual(ota.get_robot_api_key(), "robot-key")
+            self.assertEqual(rc.get_robot_api_key(), "robot-key")
 
     def test_get_robot_api_key_from_config_yaml(self):
         config_path = Path(g.script_directory) / "configuration_setting.yaml"
@@ -220,7 +267,7 @@ class TestConfiguration(unittest.TestCase):
         )
 
         with patch.dict(os.environ, {}, clear=True):
-            self.assertEqual(ota.get_robot_api_key(), "config-robot-key")
+            self.assertEqual(rc.get_robot_api_key(), "config-robot-key")
 
     def test_get_robot_api_key_env_overrides_config_yaml(self):
         config_path = Path(g.script_directory) / "configuration_setting.yaml"
@@ -236,11 +283,11 @@ class TestConfiguration(unittest.TestCase):
             },
             clear=True,
         ):
-            self.assertEqual(ota.get_robot_api_key(), "env-robot-key")
+            self.assertEqual(rc.get_robot_api_key(), "env-robot-key")
 
     def test_get_robot_node_key_from_env(self):
         with patch.dict(os.environ, {"RAISIN_ROBOT_NODE": " jetson "}, clear=True):
-            self.assertEqual(ota.get_robot_node_key(), "jetson")
+            self.assertEqual(rc.get_robot_node_key(), "jetson")
 
     def test_get_robot_node_key_from_config_yaml(self):
         config_path = Path(g.script_directory) / "configuration_setting.yaml"
@@ -250,7 +297,7 @@ class TestConfiguration(unittest.TestCase):
         )
 
         with patch.dict(os.environ, {}, clear=True):
-            self.assertEqual(ota.get_robot_node_key(), "vision")
+            self.assertEqual(rc.get_robot_node_key(), "vision")
 
     def test_save_and_read_robot_api_key_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -260,12 +307,12 @@ class TestConfiguration(unittest.TestCase):
                 {"RAISIN_ROBOT_API_KEY_FILE": str(key_path)},
                 clear=True,
             ):
-                saved_path = ota.save_robot_api_key(" robot-key ")
+                saved_path = rc.save_robot_api_key(" robot-key ")
                 self.assertEqual(saved_path, key_path)
                 if os.name == "posix":
                     self.assertEqual(saved_path.stat().st_mode & 0o777, 0o600)
-                self.assertEqual(ota.get_robot_api_key(), "robot-key")
-                self.assertEqual(ota._robot_api_key_cache[key_path][1], "robot-key")
+                self.assertEqual(rc.get_robot_api_key(), "robot-key")
+                self.assertEqual(rc._robot_api_key_cache[key_path][1], "robot-key")
 
     def test_missing_pinned_robot_api_key_file_warns(self):
         """An explicitly pinned path that yields nothing must not fail quietly."""
@@ -275,7 +322,7 @@ class TestConfiguration(unittest.TestCase):
             {"RAISIN_ROBOT_API_KEY_FILE": str(missing)},
             clear=True,
         ), patch("builtins.print") as mock_print:
-            self.assertIsNone(ota.get_robot_api_key())
+            self.assertIsNone(rc.get_robot_api_key())
 
         self.assertTrue(
             any(
@@ -292,18 +339,18 @@ class TestConfiguration(unittest.TestCase):
         )
 
         with patch.dict(os.environ, {}, clear=True):
-            first = ota._load_local_config()
+            first = rc._load_local_config()
             for _ in range(4):
-                ota._load_local_config()
+                rc._load_local_config()
             self.assertEqual(first.get("robot", {}).get("api_key"), "cfg-key")
-            self.assertEqual(len(ota._local_config_cache), 1)
+            self.assertEqual(len(rc._local_config_cache), 1)
 
             # A rewrite must invalidate the cache rather than serve stale values.
             os.utime(config_path, (0, 0))
             config_path.write_text(
                 "robot:\n  api_key: rotated-key\n  node: primary\n", encoding="utf-8"
             )
-            self.assertEqual(ota.get_robot_api_key(), "rotated-key")
+            self.assertEqual(rc.get_robot_api_key(), "rotated-key")
 
     @unittest.skipIf(os.name != "posix", "POSIX file permission check")
     def test_insecure_robot_api_key_file_is_ignored(self):
@@ -316,7 +363,7 @@ class TestConfiguration(unittest.TestCase):
                 {"RAISIN_ROBOT_API_KEY_FILE": str(key_path)},
                 clear=True,
             ):
-                self.assertIsNone(ota.get_robot_api_key())
+                self.assertIsNone(rc.get_robot_api_key())
 
     @unittest.skipIf(os.name != "posix", "POSIX file permission check")
     def test_insecure_robot_api_key_file_warning_is_cached(self):
@@ -329,8 +376,8 @@ class TestConfiguration(unittest.TestCase):
                 {"RAISIN_ROBOT_API_KEY_FILE": str(key_path)},
                 clear=True,
             ), patch("builtins.print") as mock_print:
-                self.assertIsNone(ota.get_robot_api_key())
-                self.assertIsNone(ota.get_robot_api_key())
+                self.assertIsNone(rc.get_robot_api_key())
+                self.assertIsNone(rc.get_robot_api_key())
 
             mock_print.assert_called_once()
 
@@ -995,14 +1042,7 @@ class TestInstallEventQueue(unittest.TestCase):
         queued = self._queued()
         acks = [{"eventId": e["eventId"], "status": "created"} for e in queued]
 
-        with patch.dict(
-            os.environ,
-            {
-                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-                "RAISIN_ROBOT_NODE": "jetson",
-            },
-            clear=True,
-        ), patch(
+        with _robot_identity(), patch(
             "commands.ota_client.get_ota_endpoint",
             return_value="https://ota.example.com",
         ), patch(
@@ -1024,14 +1064,7 @@ class TestInstallEventQueue(unittest.TestCase):
     def test_offline_flush_keeps_the_queue_for_later(self):
         ota.record_install_event("started")
 
-        with patch.dict(
-            os.environ,
-            {
-                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-                "RAISIN_ROBOT_NODE": "jetson",
-            },
-            clear=True,
-        ), patch(
+        with _robot_identity(), patch(
             "commands.ota_client.get_ota_endpoint",
             return_value="https://ota.example.com",
         ), patch(
@@ -1048,14 +1081,7 @@ class TestInstallEventQueue(unittest.TestCase):
         ota.record_install_event("started")
         first = [e["eventId"] for e in self._queued()]
 
-        with patch.dict(
-            os.environ,
-            {
-                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-                "RAISIN_ROBOT_NODE": "jetson",
-            },
-            clear=True,
-        ), patch(
+        with _robot_identity(), patch(
             "commands.ota_client.get_ota_endpoint",
             return_value="https://ota.example.com",
         ), patch(
@@ -1098,19 +1124,10 @@ class TestInstallEventQueue(unittest.TestCase):
                 }
             )
 
-        with patch.dict(
-            os.environ,
-            {
-                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-                "RAISIN_ROBOT_NODE": "jetson",
-            },
-            clear=True,
-        ), patch(
+        with _robot_identity(), patch(
             "commands.ota_client.get_ota_endpoint",
             return_value="https://ota.example.com",
-        ), patch(
-            "commands.ota_client.requests.post", side_effect=capture
-        ):
+        ), patch("commands.ota_client.requests.post", side_effect=capture):
             ota.flush_install_events()
 
         self.assertEqual(posted, [ota._INSTALL_EVENT_BATCH_LIMIT, 5])
@@ -1121,21 +1138,24 @@ class TestInstallEventQueue(unittest.TestCase):
 
         Buffering them there grows a file that can never be flushed.
         """
-        with patch.dict(os.environ, {}, clear=True):
+        with _no_robot_identity():
             self.assertIsNone(ota.record_install_event("started"))
             self.assertIsNone(ota.report_install_outcome(True))
 
         self.assertEqual(self._queued(), [])
         self.assertFalse(ota._install_event_queue_path().exists())
 
-    def test_api_key_without_a_node_records_nothing(self):
-        """Half-configured is not configured: the reports would be rejected."""
+    def test_half_a_credential_yields_no_identity_so_nothing_is_recorded(self):
+        """Resolution refuses it, and the core is then simply unconfigured."""
         with patch.dict(
             os.environ,
             {"RAISIN_ROBOT_API_KEY": "robot-key"},  # pragma: allowlist secret
             clear=True,
         ), patch("builtins.print"):
-            ota.record_install_event("started")
+            self.assertIsNone(rc.resolve_robot_identity())
+
+        with _no_robot_identity():
+            self.assertIsNone(ota.record_install_event("started"))
 
         self.assertEqual(self._queued(), [])
 
@@ -1144,14 +1164,7 @@ class TestInstallEventQueue(unittest.TestCase):
         for i in range(cap + 25):
             ota._append_install_event({"eventId": f"e{i}", "eventType": "started"})
 
-        with patch.dict(
-            os.environ,
-            {
-                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-                "RAISIN_ROBOT_NODE": "jetson",
-            },
-            clear=True,
-        ), patch(
+        with _robot_identity(), patch(
             "commands.ota_client.get_ota_endpoint",
             return_value="https://ota.example.com",
         ), patch(
@@ -1654,8 +1667,9 @@ class TestDownloadBlobErrorPropagation(unittest.TestCase):
     def tearDown(self):
         self._tmp.cleanup()
 
-    def _call(self, **env):
-        with patch.dict(os.environ, env, clear=True), patch(
+    def _call(self, robot=True):
+        identity = _robot_identity() if robot else _no_robot_identity()
+        with identity, patch(
             "commands.ota_client.get_ota_endpoint",
             return_value="https://ota.example.com",
         ):
@@ -1677,10 +1691,7 @@ class TestDownloadBlobErrorPropagation(unittest.TestCase):
             headers={"X-Content-Hash": hashlib.sha256(body).hexdigest()},
         )
         with patch("commands.ota_client.requests.get", return_value=resp):
-            ok, code = self._call(
-                RAISIN_ROBOT_API_KEY="robot-key",  # pragma: allowlist secret
-                RAISIN_ROBOT_NODE="jetson",
-            )
+            ok, code = self._call(robot=True)
 
         self.assertTrue(ok)
         self.assertIsNone(code)
@@ -1690,10 +1701,7 @@ class TestDownloadBlobErrorPropagation(unittest.TestCase):
             "commands.ota_client.requests.get",
             side_effect=requests.ConnectionError("refused"),
         ), patch("commands.ota_client.time.sleep"):
-            ok, code = self._call(
-                RAISIN_ROBOT_API_KEY="robot-key",  # pragma: allowlist secret
-                RAISIN_ROBOT_NODE="jetson",
-            )
+            ok, code = self._call(robot=True)
 
         self.assertFalse(ok)
         self.assertEqual(code, "network")
@@ -1705,7 +1713,7 @@ class TestDownloadBlobErrorPropagation(unittest.TestCase):
             "commands.ota_client.requests.get",
             side_effect=requests.HTTPError(response=resp),
         ), patch("commands.ota_client.time.sleep"):
-            ok, code = self._call()
+            ok, code = self._call(robot=False)
 
         self.assertFalse(ok)
         self.assertEqual(code, "server_error")
@@ -1954,10 +1962,10 @@ class TestDownload(unittest.TestCase):
         ota._auth_failed = False
         ota._archive_cache.clear()
         ota._install_session_id = None
-        ota._robot_api_key_cache.clear()
+        rc._robot_api_key_cache.clear()
         ota._pending_snapshot_reports.clear()
-        ota._robot_auth_warning_keys.clear()
-        ota._local_config_cache.clear()
+        rc._robot_auth_warning_keys.clear()
+        rc._local_config_cache.clear()
         self._orig_os_type = g.os_type
         self._orig_os_version = g.os_version
         self._orig_architecture = g.architecture
@@ -1978,8 +1986,8 @@ class TestDownload(unittest.TestCase):
         ota._archive_cache.clear()
         ota._install_session_id = None
         ota._pending_snapshot_reports.clear()
-        ota._robot_auth_warning_keys.clear()
-        ota._local_config_cache.clear()
+        rc._robot_auth_warning_keys.clear()
+        rc._local_config_cache.clear()
         g.os_type = self._orig_os_type
         _sync_ota_context()
         g.os_version = self._orig_os_version
@@ -2263,15 +2271,7 @@ class TestDownload(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             download_path = Path(tmpdir) / "pkg.zip"
-            with patch.dict(
-                os.environ,
-                {
-                    "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-                    "RAISIN_ROBOT_NODE": "jetson",
-                    "RAISIN_OTA_CLIENT_VERSION": "raisin-cli-test",
-                },
-                clear=True,
-            ):
+            with _robot_identity("raisin-cli-test"):
                 result = ota._download_package_blob(
                     "arch-1",
                     "pkg-1",
@@ -2311,35 +2311,16 @@ class TestDownload(unittest.TestCase):
         )
         self.assertEqual(call_args.kwargs["headers"]["X-Robot-Node"], "jetson")
 
-    @patch("commands.ota_client._stream_download", return_value=True)
-    @patch(
-        "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
-    )
-    def test_download_package_blob_falls_back_without_robot_node(
-        self, _ep, mock_stream
-    ):
+    def test_key_without_a_node_is_not_a_usable_identity(self):
+        """Robot endpoints resolve a node, so half a credential fails every call."""
         with patch.dict(
             os.environ,
             {"RAISIN_ROBOT_API_KEY": "robot-key"},  # pragma: allowlist secret
             clear=True,
         ), patch("builtins.print") as mock_print:
-            result = ota._download_package_blob(
-                "arch-1",
-                "pkg-1",
-                "mypkg",
-                Path("/tmp/pkg.zip"),
-                archive_name="dso",
-                archive_version="1.0.3",
-                platform_str="ubuntu-24.04-arm64",
-                install_session_id="session-1",
-            )
+            identity = rc.resolve_robot_identity()
 
-        self.assertTrue(result)
-        mock_stream.assert_called_once_with(
-            "https://ota.example.com/archives/arch-1/packages/pkg-1/download",
-            Path("/tmp/pkg.zip"),
-            "mypkg",
-        )
+        self.assertIsNone(identity)
         mock_print.assert_called_once()
 
     @patch("commands.ota_client._get_auth_context", return_value=("tok", {}))
@@ -2409,15 +2390,7 @@ class TestDownload(unittest.TestCase):
             }
         ]
 
-        with patch.dict(
-            os.environ,
-            {
-                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-                "RAISIN_ROBOT_NODE": "jetson",
-                "RAISIN_CLIENT_VERSION": "raisin-cli-test",
-            },
-            clear=True,
-        ):
+        with _robot_identity("raisin-cli-test"):
             result = ota.report_software_snapshot(
                 archive_id="arch-1",
                 archive_name="dso",
@@ -2829,14 +2802,7 @@ class TestDownload(unittest.TestCase):
 
     def _robot_download(self, headers, target):
         """Run a robot-authenticated download of b'abc' with the given headers."""
-        with patch.dict(
-            os.environ,
-            {
-                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-                "RAISIN_ROBOT_NODE": "jetson",
-            },
-            clear=True,
-        ), patch(
+        with _robot_identity(), patch(
             "commands.ota_client.get_ota_endpoint",
             return_value="https://ota.example.com",
         ), patch(
@@ -3031,14 +2997,7 @@ class TestDownload(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def _desired_state(self, payload, platform="ubuntu-24.04-arm64"):
-        with patch.dict(
-            os.environ,
-            {
-                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-                "RAISIN_ROBOT_NODE": "jetson",
-            },
-            clear=True,
-        ), patch(
+        with _robot_identity(), patch(
             "commands.ota_client.get_ota_endpoint",
             return_value="https://ota.example.com",
         ), patch(
@@ -3176,14 +3135,7 @@ class TestDownload(unittest.TestCase):
         self.assertIsNone(name)
 
     def _desired_state_output(self, payload, platform="ubuntu-24.04-arm64"):
-        with patch.dict(
-            os.environ,
-            {
-                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
-                "RAISIN_ROBOT_NODE": "jetson",
-            },
-            clear=True,
-        ), patch(
+        with _robot_identity(), patch(
             "commands.ota_client.get_ota_endpoint",
             return_value="https://ota.example.com",
         ), patch(
@@ -3265,9 +3217,9 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         ota._auth_failed = False
         ota._archive_cache.clear()
         ota._install_session_id = None
-        ota._robot_api_key_cache.clear()
-        ota._robot_auth_warning_keys.clear()
-        ota._local_config_cache.clear()
+        rc._robot_api_key_cache.clear()
+        rc._robot_auth_warning_keys.clear()
+        rc._local_config_cache.clear()
         self._orig_os_type = g.os_type
         self._orig_os_version = g.os_version
         self._orig_architecture = g.architecture
@@ -3288,9 +3240,9 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         ota._archive_cache.clear()
         ota._install_session_id = None
         ota._pending_snapshot_reports.clear()
-        ota._robot_api_key_cache.clear()
-        ota._robot_auth_warning_keys.clear()
-        ota._local_config_cache.clear()
+        rc._robot_api_key_cache.clear()
+        rc._robot_auth_warning_keys.clear()
+        rc._local_config_cache.clear()
         g.os_type = self._orig_os_type
         _sync_ota_context()
         g.os_version = self._orig_os_version

--- a/test_ota.py
+++ b/test_ota.py
@@ -832,6 +832,319 @@ class TestDownloadErrorClassification(unittest.TestCase):
         self.assertFalse(ota.is_retryable_error_code("unknown"))
 
 
+class TestInstallEventQueue(unittest.TestCase):
+    """On-disk install-event queue: buffering, replay safety, ordering.
+
+    Contract: docs/ota-install-event-contract.md. Events are append-only
+    observations of one attempt; `eventId` makes a replayed batch idempotent.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_script_directory = g.script_directory
+        g.script_directory = self._tmp.name
+        ota._install_session_id = "session-29"
+
+    def tearDown(self):
+        ota._install_session_id = None
+        g.script_directory = self._orig_script_directory
+        self._tmp.cleanup()
+
+    def _queued(self):
+        return ota._read_install_event_queue()
+
+    def test_recorded_event_carries_the_contract_fields(self):
+        ota.record_install_event("started", archive_name="dso")
+        (event,) = self._queued()
+
+        self.assertEqual(event["eventType"], "started")
+        self.assertEqual(event["installSessionId"], "session-29")
+        self.assertEqual(event["archiveName"], "dso")
+        self.assertTrue(event["eventId"])
+        self.assertTrue(event["occurredAt"].endswith("Z"))
+
+    def test_queue_survives_a_process_restart(self):
+        ota.record_install_event("started")
+        ota._install_session_id = "session-29"  # new process, same session
+
+        self.assertEqual(len(self._queued()), 1)
+
+    def test_started_is_emitted_once_per_session(self):
+        ota.record_install_event("started")
+        ota.record_install_event("started")
+
+        self.assertEqual(len(self._queued()), 1)
+
+    def test_only_one_terminal_event_per_session(self):
+        """An attempt emits exactly one terminal event, per the contract."""
+        ota.record_install_event("started")
+        ota.record_install_event("failed", error_code="network")
+        ota.record_install_event("succeeded")
+
+        types = [e["eventType"] for e in self._queued()]
+        self.assertEqual(types, ["started", "failed"])
+
+    def test_a_new_session_may_emit_its_own_terminal(self):
+        ota.record_install_event("started")
+        ota.record_install_event("succeeded")
+        ota.clear_install_session()
+        ota._install_session_id = "session-30"
+
+        ota.record_install_event("started")
+        ota.record_install_event("succeeded")
+
+        self.assertEqual(len(self._queued()), 4)
+
+    def test_flush_posts_the_batch_and_clears_acked_events(self):
+        ota.record_install_event("started")
+        ota.record_install_event("succeeded")
+        queued = self._queued()
+        acks = [{"eventId": e["eventId"], "status": "created"} for e in queued]
+
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                "RAISIN_ROBOT_NODE": "jetson",
+            },
+            clear=True,
+        ), patch(
+            "commands.ota_client.get_ota_endpoint",
+            return_value="https://ota.example.com",
+        ), patch(
+            "commands.ota_client.requests.post",
+            return_value=_mock_response(
+                json_data={"success": True, "data": {"created": 2, "acks": acks}}
+            ),
+        ) as mock_post:
+            ok = ota.flush_install_events()
+
+        self.assertTrue(ok)
+        self.assertEqual(self._queued(), [])
+        body = mock_post.call_args.kwargs["json"]
+        self.assertEqual(len(body["events"]), 2)
+        self.assertEqual(
+            mock_post.call_args.kwargs["headers"]["X-Robot-Node"], "jetson"
+        )
+
+    def test_offline_flush_keeps_the_queue_for_later(self):
+        ota.record_install_event("started")
+
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                "RAISIN_ROBOT_NODE": "jetson",
+            },
+            clear=True,
+        ), patch(
+            "commands.ota_client.get_ota_endpoint",
+            return_value="https://ota.example.com",
+        ), patch(
+            "commands.ota_client.requests.post",
+            side_effect=requests.ConnectionError("offline"),
+        ):
+            ok = ota.flush_install_events()
+
+        self.assertFalse(ok)
+        self.assertEqual(len(self._queued()), 1)
+
+    def test_replayed_batch_keeps_the_same_event_ids(self):
+        """The server dedups on eventId, so a retry must not re-mint them."""
+        ota.record_install_event("started")
+        first = [e["eventId"] for e in self._queued()]
+
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                "RAISIN_ROBOT_NODE": "jetson",
+            },
+            clear=True,
+        ), patch(
+            "commands.ota_client.get_ota_endpoint",
+            return_value="https://ota.example.com",
+        ), patch(
+            "commands.ota_client.requests.post",
+            side_effect=requests.ConnectionError("offline"),
+        ):
+            ota.flush_install_events()
+
+        self.assertEqual([e["eventId"] for e in self._queued()], first)
+
+    def test_delayed_flush_preserves_occurred_at_ordering(self):
+        with patch("commands.ota_client.time.time", side_effect=[100.5, 300.25]), patch(
+            "commands.ota_client.time.gmtime", side_effect=time.gmtime
+        ):
+            ota.record_install_event("started")
+            ota.record_install_event("succeeded")
+
+        stamps = [e["occurredAt"] for e in self._queued()]
+        self.assertEqual(stamps, sorted(stamps))
+        self.assertNotEqual(stamps[0], stamps[1])
+
+    def test_batches_are_capped_at_the_server_limit(self):
+        for i in range(ota._INSTALL_EVENT_BATCH_LIMIT + 5):
+            ota._append_install_event({"eventId": f"e{i}", "eventType": "started"})
+
+        posted = []
+
+        def capture(*a, **kw):
+            events = kw["json"]["events"]
+            posted.append(len(events))
+            return _mock_response(
+                json_data={
+                    "success": True,
+                    "data": {
+                        "acks": [
+                            {"eventId": e["eventId"], "status": "created"}
+                            for e in events
+                        ]
+                    },
+                }
+            )
+
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                "RAISIN_ROBOT_NODE": "jetson",
+            },
+            clear=True,
+        ), patch(
+            "commands.ota_client.get_ota_endpoint",
+            return_value="https://ota.example.com",
+        ), patch(
+            "commands.ota_client.requests.post", side_effect=capture
+        ):
+            ota.flush_install_events()
+
+        self.assertEqual(posted, [ota._INSTALL_EVENT_BATCH_LIMIT, 5])
+        self.assertEqual(self._queued(), [])
+
+    def test_flush_without_robot_auth_is_a_noop_that_keeps_the_queue(self):
+        ota.record_install_event("started")
+
+        with patch.dict(os.environ, {}, clear=True):
+            ok = ota.flush_install_events()
+
+        self.assertFalse(ok)
+        self.assertEqual(len(self._queued()), 1)
+
+
+class TestInstallEventEmission(unittest.TestCase):
+    """The install flow emits the events, not just the plumbing."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = (
+            g.script_directory,
+            g.os_type,
+            g.os_version,
+            g.architecture,
+        )
+        g.script_directory = self._tmp.name
+        g.os_type, g.os_version, g.architecture = "linux", "22.04", "x86_64"
+        ota._install_session_id = "session-emit"
+        ota._archive_cache.clear()
+
+    def tearDown(self):
+        ota._install_session_id = None
+        ota._archive_cache.clear()
+        (
+            g.script_directory,
+            g.os_type,
+            g.os_version,
+            g.architecture,
+        ) = self._orig
+        self._tmp.cleanup()
+
+    MANIFEST = (
+        [{"packageName": "pkg1", "packageId": "p1", "tagName": "1.0.0"}],
+        "arch-1",
+        "2026.1.0",
+    )
+
+    def _events(self):
+        return ota._read_install_event_queue()
+
+    @patch("commands.ota_client._extract_and_read_deps")
+    @patch("commands.ota_client._download_package_blob")
+    @patch("commands.ota_client._fetch_archive_manifest")
+    def test_started_event_names_the_archive(self, mock_manifest, mock_blob, mock_x):
+        mock_manifest.return_value = self.MANIFEST
+        mock_blob.return_value = (True, None)
+        mock_x.return_value = {"version": "1.0.0", "dependencies": []}
+
+        ota.download_all_from_archive(
+            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+        )
+
+        started = [e for e in self._events() if e["eventType"] == "started"]
+        self.assertEqual(len(started), 1)
+        self.assertEqual(started[0]["archiveId"], "arch-1")
+        self.assertEqual(started[0]["archiveVersion"], "2026.1.0")
+        self.assertEqual(started[0]["platform"], "linux-22.04-x86_64")
+
+    @patch("commands.ota_client._download_package_blob")
+    @patch("commands.ota_client._fetch_archive_manifest")
+    def test_download_failure_emits_failed_with_stage_and_code(
+        self, mock_manifest, mock_blob
+    ):
+        mock_manifest.return_value = self.MANIFEST
+        mock_blob.return_value = (False, "disk_full")
+
+        ota.download_all_from_archive(
+            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+        )
+
+        failed = [e for e in self._events() if e["eventType"] == "failed"]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["stage"], "download")
+        self.assertEqual(failed[0]["errorCode"], "disk_full")
+
+    @patch("commands.ota_client._extract_and_read_deps", return_value=None)
+    @patch("commands.ota_client._download_package_blob")
+    @patch("commands.ota_client._fetch_archive_manifest")
+    def test_extract_failure_emits_failed_at_unpack(
+        self, mock_manifest, mock_blob, _mock_x
+    ):
+        mock_manifest.return_value = self.MANIFEST
+        mock_blob.return_value = (True, None)
+
+        ota.download_all_from_archive(
+            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+        )
+
+        failed = [e for e in self._events() if e["eventType"] == "failed"]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["stage"], "unpack")
+        self.assertEqual(failed[0]["errorCode"], "unpack_failed")
+
+    @patch("commands.ota_client._extract_and_read_deps")
+    @patch("commands.ota_client._download_package_blob")
+    @patch("commands.ota_client._fetch_archive_manifest")
+    def test_success_is_reported_by_the_cli_not_the_download_layer(
+        self, mock_manifest, mock_blob, mock_x
+    ):
+        """The download layer cannot know the install as a whole succeeded."""
+        mock_manifest.return_value = self.MANIFEST
+        mock_blob.return_value = (True, None)
+        mock_x.return_value = {"version": "1.0.0", "dependencies": []}
+
+        ota.download_all_from_archive(
+            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+        )
+
+        types = [e["eventType"] for e in self._events()]
+        self.assertEqual(types, ["started"])
+
+        ota.record_install_event("succeeded")
+        self.assertEqual(
+            [e["eventType"] for e in self._events()], ["started", "succeeded"]
+        )
+
+
 class TestInstallSessionPersistence(unittest.TestCase):
     """A resumed install must keep its session id.
 
@@ -2611,6 +2924,50 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
 # ============================================================================
 # 6. Integration: install.py
 # ============================================================================
+
+
+class TestInstallCliEventReporting(unittest.TestCase):
+    """The CLI closes the attempt: terminal event, then flush."""
+
+    def _run_cli(self, overall_success):
+        """Drive install_cli_command past the per-package work to its tail."""
+        import click
+
+        from commands import install as install_mod
+
+        with patch.object(
+            install_mod, "install_command", return_value=overall_success
+        ), patch.object(
+            install_mod, "record_install_event"
+        ) as mock_event, patch.object(
+            install_mod, "flush_install_events"
+        ) as mock_flush, patch.object(
+            install_mod, "flush_pending_snapshot_reports"
+        ), patch.object(
+            install_mod, "clear_install_session"
+        ):
+            try:
+                # It is a click Command; call the underlying function.
+                install_mod.install_cli_command.callback(
+                    ["mypkg"], "release", False, None, None, None, False, "stable"
+                )
+            except click.exceptions.Exit:
+                pass
+        return mock_event, mock_flush
+
+    def test_successful_run_reports_succeeded_then_flushes(self):
+        mock_event, mock_flush = self._run_cli(overall_success=True)
+
+        mock_event.assert_called_once()
+        self.assertEqual(mock_event.call_args.args[0], "succeeded")
+        mock_flush.assert_called_once()
+
+    def test_failed_run_still_flushes_what_was_buffered(self):
+        """A failed attempt already emitted its terminal event downstream."""
+        mock_event, mock_flush = self._run_cli(overall_success=False)
+
+        mock_event.assert_not_called()
+        mock_flush.assert_called_once()
 
 
 class TestInstallIntegration(unittest.TestCase):

--- a/test_ota.py
+++ b/test_ota.py
@@ -3125,6 +3125,53 @@ class TestDownload(unittest.TestCase):
         self.assertFalse(halted)
         self.assertIsNone(name)
 
+    def _desired_state_output(self, payload, platform="ubuntu-24.04-arm64"):
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                "RAISIN_ROBOT_NODE": "jetson",
+            },
+            clear=True,
+        ), patch(
+            "commands.ota_client.get_ota_endpoint",
+            return_value="https://ota.example.com",
+        ), patch(
+            "commands.ota_client.requests.get",
+            return_value=_mock_response(json_data={"success": True, "data": payload}),
+        ), patch(
+            "builtins.print"
+        ) as mock_print:
+            ota._resolve_desired_state(platform)
+        return " ".join(str(c) for c in mock_print.call_args_list)
+
+    def test_no_target_says_the_node_is_unassigned(self):
+        """Otherwise the legacy-route warnings that follow read as a failure.
+
+        A robot with no assignment is in a normal state; the SSH and GitHub
+        fallback warnings make it look like its credential is broken.
+        """
+        output = self._desired_state_output({"halt": False, "reason": "no_target"})
+
+        self.assertIn("no archive", output.lower())
+        self.assertIn("assign", output.lower())
+
+    def test_an_assigned_target_says_nothing_about_being_unassigned(self):
+        output = self._desired_state_output(
+            {
+                "halt": False,
+                "reason": "node_pin",
+                "target": {
+                    "archiveId": "arch-1",
+                    "name": "raisin-robot",
+                    "version": "2026.1.0",
+                    "platform": "ubuntu-24.04-arm64",
+                },
+            }
+        )
+
+        self.assertNotIn("no archive", output.lower())
+
     def test_resolve_desired_state_without_robot_auth_is_inert(self):
         with patch.dict(os.environ, {}, clear=True):
             self.assertEqual(

--- a/test_ota.py
+++ b/test_ota.py
@@ -2940,8 +2940,94 @@ class TestDownload(unittest.TestCase):
         ):
             return ota._resolve_desired_state(platform)
 
+    def test_desired_state_supplies_the_package_manifest(self):
+        """#37: the target carries the package list, so no JWT is needed."""
+        halted, name, version, manifest = self._desired_state(
+            {
+                "halt": False,
+                "reason": "node_pin",
+                "target": {
+                    "archiveId": "arch-1",
+                    "name": "raisin-robot",
+                    "version": "2026.1.0",
+                    "platform": "ubuntu-24.04-arm64",
+                    "packages": [
+                        {
+                            "packageId": "p1",
+                            "packageName": "pkg1",
+                            "manifestHash": "a" * 64,
+                            "tagName": "0.1.0",
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertFalse(halted)
+        self.assertEqual((name, version), ("raisin-robot", "2026.1.0"))
+        packages, archive_id, actual_version = manifest
+        self.assertEqual(archive_id, "arch-1")
+        self.assertEqual(actual_version, "2026.1.0")
+        self.assertEqual(packages[0]["packageId"], "p1")
+
+    def test_target_without_packages_supplies_no_manifest(self):
+        """An older server sends no package list; fall back to the JWT path."""
+        _halted, _name, _version, manifest = self._desired_state(
+            {
+                "halt": False,
+                "reason": "node_pin",
+                "target": {
+                    "archiveId": "arch-1",
+                    "name": "raisin-robot",
+                    "version": "2026.1.0",
+                    "platform": "ubuntu-24.04-arm64",
+                },
+            }
+        )
+
+        self.assertIsNone(manifest)
+
+    @patch("commands.ota_client._extract_and_read_deps")
+    @patch("commands.ota_client._download_package_blob", return_value=(True, None))
+    @patch("commands.ota_client._fetch_archive_manifest")
+    @patch("commands.ota_client._resolve_desired_state")
+    def test_install_uses_the_desired_state_manifest_without_jwt(
+        self, mock_desired, mock_fetch, _mock_blob, mock_extract
+    ):
+        """The whole point: an API-key-only robot never touches the JWT route."""
+        packages = [
+            {
+                "packageId": "p1",
+                "packageName": "pkg1",
+                "manifestHash": "a" * 64,
+                "tagName": "0.1.0",
+            }
+        ]
+        mock_desired.return_value = (
+            False,
+            "raisin-robot",
+            "2026.1.0",
+            (packages, "arch-1", "2026.1.0"),
+        )
+
+        def extract(download_file, install_dir, package_name, version, **kw):
+            install_dir.mkdir(parents=True, exist_ok=True)
+            (install_dir / "release.yaml").write_text("version: 0.1.0\n")
+            return {"version": version, "dependencies": []}
+
+        mock_extract.side_effect = extract
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            g.script_directory = tmpdir
+            live = Path(tmpdir) / "release" / "install"
+            live.parent.mkdir(parents=True, exist_ok=True)
+            results = ota.download_all_from_archive("release", live)
+
+        self.assertEqual(sorted(results), ["pkg1"])
+        mock_fetch.assert_not_called()
+
     def test_resolve_desired_state_returns_assigned_target(self):
-        halted, name, version = self._desired_state(
+        halted, name, version, _manifest = self._desired_state(
             {
                 "halt": False,
                 "reason": "node_pin",
@@ -2957,14 +3043,14 @@ class TestDownload(unittest.TestCase):
         self.assertEqual((halted, name, version), (False, "raisin-robot", "2026.1.0"))
 
     def test_resolve_desired_state_honours_halt(self):
-        halted, name, version = self._desired_state(
+        halted, name, version, _manifest = self._desired_state(
             {"halt": True, "haltSources": ["tenant"], "reason": "node_pin"}
         )
 
         self.assertEqual((halted, name, version), (True, None, None))
 
     def test_resolve_desired_state_ignores_target_for_other_platform(self):
-        halted, name, _ = self._desired_state(
+        halted, name, _version, _manifest = self._desired_state(
             {
                 "halt": False,
                 "reason": "node_pin",
@@ -2982,7 +3068,8 @@ class TestDownload(unittest.TestCase):
     def test_resolve_desired_state_without_robot_auth_is_inert(self):
         with patch.dict(os.environ, {}, clear=True):
             self.assertEqual(
-                ota._resolve_desired_state("ubuntu-24.04-arm64"), (False, None, None)
+                ota._resolve_desired_state("ubuntu-24.04-arm64"),
+                (False, None, None, None),
             )
 
     @patch("commands.ota_client._fetch_archive_with_stable_fallback")
@@ -2990,7 +3077,7 @@ class TestDownload(unittest.TestCase):
     def test_download_all_from_archive_aborts_when_halted(
         self, mock_desired, mock_fetch
     ):
-        mock_desired.return_value = (True, None, None)
+        mock_desired.return_value = (True, None, None, None)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             result = ota.download_all_from_archive("release", Path(tmpdir))

--- a/test_ota.py
+++ b/test_ota.py
@@ -758,7 +758,20 @@ class TestUpload(unittest.TestCase):
         # Server wraps responses in {"data": ...}
         mock_get.side_effect = [
             _mock_response(json_data={"data": {"exists": False}}),
-            _mock_response(json_data={"data": [{"id": "pkg-1"}]}),
+            _mock_response(
+                json_data={
+                    "data": {
+                        "packages": [
+                            {"id": "other", "name": "mypkg_extra"},
+                            {"id": "pkg-1", "name": "mypkg"},
+                        ],
+                        "total": 2,
+                        "page": 1,
+                        "limit": 100,
+                        "totalPages": 1,
+                    }
+                }
+            ),
         ]
 
         # POST blob upload, POST manifest, POST tag
@@ -789,7 +802,20 @@ class TestUpload(unittest.TestCase):
         # GET packages → existing package
         mock_get.side_effect = [
             _mock_response(json_data={"data": {"exists": True}}),
-            _mock_response(json_data={"data": [{"id": "pkg-1"}]}),
+            _mock_response(
+                json_data={
+                    "data": {
+                        "packages": [
+                            {"id": "other", "name": "mypkg_extra"},
+                            {"id": "pkg-1", "name": "mypkg"},
+                        ],
+                        "total": 2,
+                        "page": 1,
+                        "limit": 100,
+                        "totalPages": 1,
+                    }
+                }
+            ),
         ]
 
         # POST manifest, POST tag (no blob upload)
@@ -834,7 +860,20 @@ class TestUpload(unittest.TestCase):
             ),
             # Retry calls (after re-auth):
             _mock_response(json_data={"data": {"exists": True}}),
-            _mock_response(json_data={"data": [{"id": "pkg-1"}]}),
+            _mock_response(
+                json_data={
+                    "data": {
+                        "packages": [
+                            {"id": "other", "name": "mypkg_extra"},
+                            {"id": "pkg-1", "name": "mypkg"},
+                        ],
+                        "total": 2,
+                        "page": 1,
+                        "limit": 100,
+                        "totalPages": 1,
+                    }
+                }
+            ),
         ]
         mock_post.side_effect = [
             _mock_response(),  # manifest
@@ -966,6 +1005,146 @@ class TestMalformedReleaseYaml(unittest.TestCase):
         )
 
         self.assertEqual(result["dependencies"], ["depA"])
+
+
+class TestPackageLookup(unittest.TestCase):
+    """`GET /packages` takes search/page/limit — not `name`, and limit caps at 100.
+
+    The endpoint rejects anything else, and the rejection was being reported as
+    "package not found", which sends the operator looking in the wrong place.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = g.script_directory
+        g.script_directory = self._tmp.name
+        _sync_ota_context()
+
+    def tearDown(self):
+        g.script_directory = self._orig
+        self._tmp.cleanup()
+
+    @staticmethod
+    def _page(names, total=None, page=1, limit=100):
+        return _mock_response(
+            json_data={
+                "success": True,
+                "data": {
+                    "packages": [{"id": f"id-{n}", "name": n} for n in names],
+                    "total": total if total is not None else len(names),
+                    "page": page,
+                    "limit": limit,
+                    "totalPages": -(
+                        -(total if total is not None else len(names)) // limit
+                    ),
+                },
+            }
+        )
+
+    @patch("commands.ota_client._get_auth_context", return_value=("https://x", {}))
+    @patch("commands.ota_client.requests.get")
+    def test_lookup_searches_rather_than_sending_an_unknown_parameter(
+        self, mock_get, _ctx
+    ):
+        mock_get.return_value = self._page(["raisin"])
+
+        ota._fetch_package_id_by_name("raisin")
+
+        sent = mock_get.call_args.kwargs["params"]
+        self.assertNotIn("name", sent)
+        self.assertEqual(sent["search"], "raisin")
+        self.assertLessEqual(sent["limit"], 100)
+
+    @patch("commands.ota_client._get_auth_context", return_value=("https://x", {}))
+    @patch("commands.ota_client.requests.get")
+    def test_lookup_returns_the_exact_name_not_the_first_result(self, mock_get, _ctx):
+        """`search` is a substring match over name and description."""
+        mock_get.return_value = self._page(["raisin_gui", "raisin", "raisin_plugin"])
+
+        self.assertEqual(ota._fetch_package_id_by_name("raisin"), "id-raisin")
+
+    @patch("commands.ota_client._get_auth_context", return_value=("https://x", {}))
+    @patch("commands.ota_client.requests.get")
+    def test_lookup_walks_pages_to_find_the_exact_name(self, mock_get, _ctx):
+        mock_get.side_effect = [
+            self._page(["raisin_a"], total=2, page=1, limit=1),
+            self._page(["raisin"], total=2, page=2, limit=1),
+        ]
+
+        self.assertEqual(
+            ota._fetch_package_id_by_name("raisin", page_size=1), "id-raisin"
+        )
+
+    @patch("commands.ota_client._get_auth_context", return_value=("https://x", {}))
+    @patch("commands.ota_client.requests.get")
+    def test_a_rejected_request_is_reported_as_a_rejection(self, mock_get, _ctx):
+        """Not as an absent package — that sends the operator to the wrong place."""
+        rejected = _mock_response(
+            status_code=400,
+            json_data={
+                "success": False,
+                "error": {
+                    "message": "Validation failed",
+                    "validationErrors": [
+                        {
+                            "field": "property",
+                            "message": "property name should not exist",
+                        }
+                    ],
+                },
+            },
+        )
+        rejected.raise_for_status.side_effect = requests.HTTPError(response=rejected)
+        mock_get.return_value = rejected
+
+        with patch("builtins.print") as mock_print:
+            result = ota._fetch_package_id_by_name("raisin")
+
+        self.assertIsNone(result)
+        output = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("reject", output.lower())
+        self.assertIn("property name should not exist", output)
+        self.assertNotIn("not found", output.lower())
+
+    @patch("commands.ota_client._get_auth_context", return_value=("https://x", {}))
+    @patch("commands.ota_client.requests.get")
+    def test_a_missing_package_is_reported_as_missing(self, mock_get, _ctx):
+        mock_get.return_value = self._page([])
+
+        with patch("builtins.print") as mock_print:
+            self.assertIsNone(ota._fetch_package_id_by_name("nope"))
+
+        output = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("not found", output.lower())
+        self.assertNotIn("reject", output.lower())
+
+    @patch("commands.ota_client._get_auth_context", return_value=("https://x", {}))
+    @patch("commands.ota_client.requests.get")
+    def test_a_refused_page_does_not_become_a_shorter_list(self, mock_get, _ctx):
+        """Half a list reads as "these are all the packages" — the same lie."""
+        refused = _mock_response(status_code=400, json_data={"success": False})
+        refused.raise_for_status.side_effect = requests.HTTPError(response=refused)
+        mock_get.side_effect = [
+            self._page(["a", "b"], total=4, page=1, limit=2),
+            refused,
+        ]
+
+        with patch("builtins.print"):
+            self.assertIsNone(ota._list_all_packages(page_size=2))
+
+    @patch("commands.ota_client._get_auth_context", return_value=("https://x", {}))
+    @patch("commands.ota_client.requests.get")
+    def test_listing_every_package_stays_within_the_page_limit(self, mock_get, _ctx):
+        mock_get.side_effect = [
+            self._page(["a", "b"], total=3, page=1, limit=2),
+            self._page(["c"], total=3, page=2, limit=2),
+        ]
+
+        names = [p["name"] for p in ota._list_all_packages(page_size=2)]
+
+        self.assertEqual(names, ["a", "b", "c"])
+        for call in mock_get.call_args_list:
+            self.assertLessEqual(call.kwargs["params"]["limit"], 100)
 
 
 class TestInstallEventQueue(unittest.TestCase):

--- a/test_ota.py
+++ b/test_ota.py
@@ -16,6 +16,7 @@ import errno
 import hashlib
 import json
 import os
+import shutil
 import struct
 import sys
 import tempfile
@@ -30,6 +31,7 @@ from click.testing import CliRunner
 
 import commands.ota_client as ota
 from commands import globals as g
+from commands import install_tree
 
 
 # ---------------------------------------------------------------------------
@@ -1069,8 +1071,22 @@ class TestInstallEventEmission(unittest.TestCase):
         "2026.1.0",
     )
 
+    def _ota_install_path(self):
+        """release/install — distinct from <script_dir>/install, the build tree."""
+        path = Path(self._tmp.name) / "release" / "install"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
     def _events(self):
         return ota._read_install_event_queue()
+
+    @staticmethod
+    def _real_extract(download_file, install_dir, package_name, version, **kw):
+        install_dir.mkdir(parents=True, exist_ok=True)
+        (install_dir / "release.yaml").write_text(
+            f"version: {version}\n", encoding="utf-8"
+        )
+        return {"version": version, "dependencies": []}
 
     @patch("commands.ota_client._extract_and_read_deps")
     @patch("commands.ota_client._download_package_blob")
@@ -1078,10 +1094,10 @@ class TestInstallEventEmission(unittest.TestCase):
     def test_started_event_names_the_archive(self, mock_manifest, mock_blob, mock_x):
         mock_manifest.return_value = self.MANIFEST
         mock_blob.return_value = (True, None)
-        mock_x.return_value = {"version": "1.0.0", "dependencies": []}
+        mock_x.side_effect = self._real_extract
 
         ota.download_all_from_archive(
-            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+            "release", self._ota_install_path(), archive_version="2026.1.0"
         )
 
         started = [e for e in self._events() if e["eventType"] == "started"]
@@ -1100,7 +1116,7 @@ class TestInstallEventEmission(unittest.TestCase):
         mock_blob.return_value = (False, "disk_full")
 
         ota.download_all_from_archive(
-            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+            "release", self._ota_install_path(), archive_version="2026.1.0"
         )
 
         self.assertEqual([e["eventType"] for e in self._events()], ["started"])
@@ -1116,7 +1132,7 @@ class TestInstallEventEmission(unittest.TestCase):
         mock_blob.return_value = (True, None)
 
         ota.download_all_from_archive(
-            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+            "release", self._ota_install_path(), archive_version="2026.1.0"
         )
 
         self.assertEqual([e["eventType"] for e in self._events()], ["started"])
@@ -1141,7 +1157,7 @@ class TestInstallEventEmission(unittest.TestCase):
         mock_x.return_value = None
 
         ota.download_all_from_archive(
-            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+            "release", self._ota_install_path(), archive_version="2026.1.0"
         )
 
         self.assertEqual(ota.pending_install_failure(), ("download", "server_error"))
@@ -1154,9 +1170,8 @@ class TestInstallEventEmission(unittest.TestCase):
     ):
         """4-of-5 installed is not a completed archive install.
 
-        install_command returns True when *any* package landed, so without the
-        noted failure the attempt would report `succeeded` while the server was
-        told a package never arrived.
+        Nothing is committed, so the previous version keeps running and the
+        attempt reports why rather than claiming success.
         """
         mock_manifest.return_value = (
             [
@@ -1170,10 +1185,10 @@ class TestInstallEventEmission(unittest.TestCase):
         mock_x.return_value = {"version": "1.0.0", "dependencies": []}
 
         results = ota.download_all_from_archive(
-            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+            "release", self._ota_install_path(), archive_version="2026.1.0"
         )
 
-        self.assertEqual(list(results), ["pkg2"])  # partial success
+        self.assertEqual(results, {})  # nothing committed
         self.assertIsNotNone(ota.pending_install_failure())
 
     @patch("commands.ota_client._extract_and_read_deps")
@@ -1185,10 +1200,10 @@ class TestInstallEventEmission(unittest.TestCase):
         """The download layer cannot know the install as a whole succeeded."""
         mock_manifest.return_value = self.MANIFEST
         mock_blob.return_value = (True, None)
-        mock_x.return_value = {"version": "1.0.0", "dependencies": []}
+        mock_x.side_effect = self._real_extract
 
         ota.download_all_from_archive(
-            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+            "release", self._ota_install_path(), archive_version="2026.1.0"
         )
 
         types = [e["eventType"] for e in self._events()]
@@ -1199,6 +1214,220 @@ class TestInstallEventEmission(unittest.TestCase):
         self.assertEqual(
             [e["eventType"] for e in self._events()], ["started", "succeeded"]
         )
+
+
+class TestTransactionalArchiveInstall(unittest.TestCase):
+    """An archive install commits all-or-nothing, or not at all."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = (g.script_directory, g.os_type, g.os_version, g.architecture)
+        g.script_directory = self._tmp.name
+        g.os_type, g.os_version, g.architecture = "linux", "22.04", "x86_64"
+        ota._install_session_id = "session-tx"
+        ota._archive_cache.clear()
+        ota.clear_pending_install_failure()
+        self.release = Path(self._tmp.name) / "release"
+        self.release.mkdir(parents=True)
+        self.live = self.release / "install"
+
+    def tearDown(self):
+        ota._install_session_id = None
+        ota._archive_cache.clear()
+        ota.clear_pending_install_failure()
+        (g.script_directory, g.os_type, g.os_version, g.architecture) = self._orig
+        self._tmp.cleanup()
+
+    MANIFEST = (
+        [
+            {"packageName": "pkg1", "packageId": "p1", "tagName": "1.0.0"},
+            {"packageName": "pkg2", "packageId": "p2", "tagName": "1.0.0"},
+        ],
+        "arch-1",
+        "2026.2.0",
+    )
+
+    def _extract_into(self, staging_names):
+        """Stand in for extraction: write each package into the staged tree."""
+
+        def fake(download_file, install_dir, package_name, version, **kw):
+            if package_name not in staging_names:
+                return None
+            install_dir.mkdir(parents=True, exist_ok=True)
+            (install_dir / "release.yaml").write_text(
+                f"version: {version}\n", encoding="utf-8"
+            )
+            return {"version": version, "dependencies": []}
+
+        return fake
+
+    def _run(self, installable, **kwargs):
+        with patch(
+            "commands.ota_client._fetch_archive_manifest", return_value=self.MANIFEST
+        ), patch(
+            "commands.ota_client._download_package_blob", return_value=(True, None)
+        ), patch(
+            "commands.ota_client._extract_and_read_deps",
+            side_effect=self._extract_into(installable),
+        ), patch(
+            "commands.ota_client.report_software_snapshot", return_value=True
+        ):
+            return ota.download_all_from_archive(
+                "release", self.live, archive_version="2026.2.0", **kwargs
+            )
+
+    def test_complete_install_commits_and_goes_live(self):
+        results = self._run({"pkg1", "pkg2"})
+
+        self.assertEqual(sorted(results), ["pkg1", "pkg2"])
+        self.assertTrue(self.live.is_symlink())
+        self.assertEqual(install_tree.current_version(self.release), "2026.2.0")
+        self.assertTrue(
+            (self.live / "pkg2" / "linux" / "22.04" / "x86_64" / "release").is_dir()
+        )
+
+    def test_missing_package_does_not_commit(self):
+        """A partial archive is not an installed archive."""
+        results = self._run({"pkg1"})
+
+        self.assertEqual(results, {})
+        self.assertIsNone(install_tree.current_version(self.release))
+        self.assertIsNotNone(ota.pending_install_failure())
+
+    def test_previous_version_keeps_running_when_an_install_fails(self):
+        self._run({"pkg1", "pkg2"})
+        ota.clear_pending_install_failure()
+        ota._install_session_id = "session-tx-2"
+
+        with patch(
+            "commands.ota_client._fetch_archive_manifest",
+            return_value=(self.MANIFEST[0], "arch-2", "2026.3.0"),
+        ), patch(
+            "commands.ota_client._download_package_blob", return_value=(True, None)
+        ), patch(
+            "commands.ota_client._extract_and_read_deps",
+            side_effect=self._extract_into({"pkg1"}),
+        ):
+            ota.download_all_from_archive(
+                "release", self.live, archive_version="2026.3.0"
+            )
+
+        self.assertEqual(install_tree.current_version(self.release), "2026.2.0")
+
+    def test_package_filter_defines_what_must_be_installed(self):
+        """`raisin install pkg1` must not fail because pkg2 is broken."""
+        results = self._run({"pkg1"}, package_filter=["pkg1"])
+
+        self.assertEqual(sorted(results), ["pkg1"])
+        self.assertEqual(install_tree.current_version(self.release), "2026.2.0")
+
+    def test_untouched_packages_survive_a_filtered_install(self):
+        self._run({"pkg1", "pkg2"})
+        ota._install_session_id = "session-tx-3"
+        ota.clear_pending_install_failure()
+
+        with patch(
+            "commands.ota_client._fetch_archive_manifest",
+            return_value=(self.MANIFEST[0], "arch-1", "2026.3.0"),
+        ), patch(
+            "commands.ota_client._download_package_blob", return_value=(True, None)
+        ), patch(
+            "commands.ota_client._extract_and_read_deps",
+            side_effect=self._extract_into({"pkg1"}),
+        ), patch(
+            "commands.ota_client.report_software_snapshot", return_value=True
+        ):
+            ota.download_all_from_archive(
+                "release",
+                self.live,
+                archive_version="2026.3.0",
+                package_filter=["pkg1"],
+            )
+
+        self.assertTrue(
+            (self.live / "pkg2" / "linux" / "22.04" / "x86_64" / "release").is_dir()
+        )
+
+    def _run_with_hollow_extract(self, version):
+        """Extraction claims success but writes nothing — a broken commit."""
+
+        def hollow(download_file, install_dir, package_name, version_, **kw):
+            # Real extraction clears the directory before unpacking; this one
+            # clears it and then writes nothing, while claiming success.
+            if install_dir.exists():
+                shutil.rmtree(install_dir)
+            install_dir.mkdir(parents=True, exist_ok=True)
+            return {"version": version_, "dependencies": []}
+
+        with patch(
+            "commands.ota_client._fetch_archive_manifest",
+            return_value=(self.MANIFEST[0], "arch-1", version),
+        ), patch(
+            "commands.ota_client._download_package_blob", return_value=(True, None)
+        ), patch(
+            "commands.ota_client._extract_and_read_deps", side_effect=hollow
+        ), patch(
+            "commands.ota_client.report_software_snapshot", return_value=True
+        ):
+            return ota.download_all_from_archive(
+                "release", self.live, archive_version=version
+            )
+
+    def test_broken_commit_rolls_back_to_the_previous_version(self):
+        self._run({"pkg1", "pkg2"})
+        ota.clear_pending_install_failure()
+        ota._install_session_id = "session-tx-rb"
+
+        results = self._run_with_hollow_extract("2026.3.0")
+
+        self.assertEqual(results, {})
+        self.assertEqual(install_tree.current_version(self.release), "2026.2.0")
+        self.assertTrue(
+            (self.live / "pkg2" / "linux" / "22.04" / "x86_64" / "release").is_dir()
+        )
+
+    def test_rollback_is_reported_as_rolled_back_not_failed(self):
+        """The contract separates the two: one switched and came back, one never did."""
+        self._run({"pkg1", "pkg2"})
+        ota.clear_pending_install_failure()
+        ota._install_session_id = "session-tx-rb2"
+
+        self._run_with_hollow_extract("2026.3.0")
+
+        terminal = [
+            e
+            for e in ota._read_install_event_queue()
+            if e["installSessionId"] == "session-tx-rb2"
+            and e["eventType"] in ("failed", "rolled_back", "succeeded")
+        ]
+        self.assertEqual([e["eventType"] for e in terminal], ["rolled_back"])
+        self.assertEqual(terminal[0]["errorCode"], "health_check_failed")
+
+    def test_broken_first_install_cannot_roll_back_and_says_so(self):
+        """With no previous version there is nothing to restore — that is `failed`."""
+        ota._install_session_id = "session-tx-first"
+
+        self._run_with_hollow_extract("2026.2.0")
+
+        terminal = [
+            e
+            for e in ota._read_install_event_queue()
+            if e["installSessionId"] == "session-tx-first"
+            and e["eventType"] in ("failed", "rolled_back")
+        ]
+        self.assertEqual([e["eventType"] for e in terminal], ["failed"])
+
+    def test_a_legacy_directory_is_adopted_before_installing(self):
+        legacy_pkg = self.live / "old_pkg" / "linux" / "22.04" / "x86_64" / "release"
+        legacy_pkg.mkdir(parents=True)
+        (legacy_pkg / "release.yaml").write_text("version: 0.1\n", encoding="utf-8")
+
+        self._run({"pkg1", "pkg2"})
+
+        self.assertTrue(self.live.is_symlink())
+        # The adopted tree is the rollback target, so its packages are still there.
+        previous = install_tree.previous_version(self.release)
+        self.assertEqual(previous, "legacy")
 
 
 class TestInstallSessionPersistence(unittest.TestCase):

--- a/test_ota.py
+++ b/test_ota.py
@@ -844,9 +844,11 @@ class TestInstallEventQueue(unittest.TestCase):
         self._orig_script_directory = g.script_directory
         g.script_directory = self._tmp.name
         ota._install_session_id = "session-29"
+        ota.clear_pending_install_failure()
 
     def tearDown(self):
         ota._install_session_id = None
+        ota.clear_pending_install_failure()
         g.script_directory = self._orig_script_directory
         self._tmp.cleanup()
 
@@ -1047,10 +1049,12 @@ class TestInstallEventEmission(unittest.TestCase):
         g.os_type, g.os_version, g.architecture = "linux", "22.04", "x86_64"
         ota._install_session_id = "session-emit"
         ota._archive_cache.clear()
+        ota.clear_pending_install_failure()
 
     def tearDown(self):
         ota._install_session_id = None
         ota._archive_cache.clear()
+        ota.clear_pending_install_failure()
         (
             g.script_directory,
             g.os_type,
@@ -1088,9 +1092,10 @@ class TestInstallEventEmission(unittest.TestCase):
 
     @patch("commands.ota_client._download_package_blob")
     @patch("commands.ota_client._fetch_archive_manifest")
-    def test_download_failure_emits_failed_with_stage_and_code(
+    def test_download_failure_is_noted_but_not_terminal_yet(
         self, mock_manifest, mock_blob
     ):
+        """A terminal event means the attempt finished — the loop has not."""
         mock_manifest.return_value = self.MANIFEST
         mock_blob.return_value = (False, "disk_full")
 
@@ -1098,15 +1103,13 @@ class TestInstallEventEmission(unittest.TestCase):
             "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
         )
 
-        failed = [e for e in self._events() if e["eventType"] == "failed"]
-        self.assertEqual(len(failed), 1)
-        self.assertEqual(failed[0]["stage"], "download")
-        self.assertEqual(failed[0]["errorCode"], "disk_full")
+        self.assertEqual([e["eventType"] for e in self._events()], ["started"])
+        self.assertEqual(ota.pending_install_failure(), ("download", "disk_full"))
 
     @patch("commands.ota_client._extract_and_read_deps", return_value=None)
     @patch("commands.ota_client._download_package_blob")
     @patch("commands.ota_client._fetch_archive_manifest")
-    def test_extract_failure_emits_failed_at_unpack(
+    def test_extract_failure_is_noted_at_the_unpack_stage(
         self, mock_manifest, mock_blob, _mock_x
     ):
         mock_manifest.return_value = self.MANIFEST
@@ -1116,10 +1119,62 @@ class TestInstallEventEmission(unittest.TestCase):
             "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
         )
 
-        failed = [e for e in self._events() if e["eventType"] == "failed"]
-        self.assertEqual(len(failed), 1)
-        self.assertEqual(failed[0]["stage"], "unpack")
-        self.assertEqual(failed[0]["errorCode"], "unpack_failed")
+        self.assertEqual([e["eventType"] for e in self._events()], ["started"])
+        self.assertEqual(ota.pending_install_failure(), ("unpack", "unpack_failed"))
+
+    @patch("commands.ota_client._extract_and_read_deps")
+    @patch("commands.ota_client._download_package_blob")
+    @patch("commands.ota_client._fetch_archive_manifest")
+    def test_first_failure_wins_when_several_packages_fail(
+        self, mock_manifest, mock_blob, mock_x
+    ):
+        """One terminal event per attempt, so the first cause is the reported one."""
+        mock_manifest.return_value = (
+            [
+                {"packageName": "pkg1", "packageId": "p1", "tagName": "1.0.0"},
+                {"packageName": "pkg2", "packageId": "p2", "tagName": "1.0.0"},
+            ],
+            "arch-1",
+            "2026.1.0",
+        )
+        mock_blob.side_effect = [(False, "server_error"), (True, None)]
+        mock_x.return_value = None
+
+        ota.download_all_from_archive(
+            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+        )
+
+        self.assertEqual(ota.pending_install_failure(), ("download", "server_error"))
+
+    @patch("commands.ota_client._extract_and_read_deps")
+    @patch("commands.ota_client._download_package_blob")
+    @patch("commands.ota_client._fetch_archive_manifest")
+    def test_partial_archive_install_is_not_a_success(
+        self, mock_manifest, mock_blob, mock_x
+    ):
+        """4-of-5 installed is not a completed archive install.
+
+        install_command returns True when *any* package landed, so without the
+        noted failure the attempt would report `succeeded` while the server was
+        told a package never arrived.
+        """
+        mock_manifest.return_value = (
+            [
+                {"packageName": "pkg1", "packageId": "p1", "tagName": "1.0.0"},
+                {"packageName": "pkg2", "packageId": "p2", "tagName": "1.0.0"},
+            ],
+            "arch-1",
+            "2026.1.0",
+        )
+        mock_blob.side_effect = [(False, "network"), (True, None)]
+        mock_x.return_value = {"version": "1.0.0", "dependencies": []}
+
+        results = ota.download_all_from_archive(
+            "release", Path(self._tmp.name) / "install", archive_version="2026.1.0"
+        )
+
+        self.assertEqual(list(results), ["pkg2"])  # partial success
+        self.assertIsNotNone(ota.pending_install_failure())
 
     @patch("commands.ota_client._extract_and_read_deps")
     @patch("commands.ota_client._download_package_blob")
@@ -1138,6 +1193,7 @@ class TestInstallEventEmission(unittest.TestCase):
 
         types = [e["eventType"] for e in self._events()]
         self.assertEqual(types, ["started"])
+        self.assertIsNone(ota.pending_install_failure())
 
         ota.record_install_event("succeeded")
         self.assertEqual(
@@ -1367,6 +1423,34 @@ class TestResumableDownload(unittest.TestCase):
         self.assertEqual(sent["If-Range"], f'"{self.digest}"')
         self.assertTrue(ok)
         self.assertEqual(self.dest.read_bytes(), self.BODY)
+
+    def test_206_at_the_wrong_offset_is_rejected(self):
+        """Appending a slice that does not start where we asked corrupts the file.
+
+        The hash check would eventually catch it, but only after a full
+        re-download and while reporting a misleading hash_mismatch.
+        """
+        self.part.write_bytes(self.BODY[:8])
+        ota._write_part_state(self.part, self.digest)
+
+        resp = _mock_response(
+            status_code=206,
+            iter_content=[self.BODY[4:]],
+            headers={
+                "X-Content-Hash": self.digest,
+                "Content-Range": f"bytes 4-{len(self.BODY) - 1}/{len(self.BODY)}",
+            },
+        )
+        with patch("commands.ota_client.requests.get", return_value=resp), patch(
+            "commands.ota_client.time.sleep"
+        ):
+            ok, code = ota._download_to_path(
+                "https://ota.example.com/x", self.dest, max_attempts=1
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(code, "network")
+        self.assertFalse(self.dest.exists())
 
     def test_server_ignoring_range_restarts_cleanly(self):
         """A 200 answer to a Range request means the object changed."""
@@ -2927,10 +3011,9 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
 
 
 class TestInstallCliEventReporting(unittest.TestCase):
-    """The CLI closes the attempt: terminal event, then flush."""
+    """The CLI closes the attempt, then flushes."""
 
     def _run_cli(self, overall_success):
-        """Drive install_cli_command past the per-package work to its tail."""
         import click
 
         from commands import install as install_mod
@@ -2938,8 +3021,8 @@ class TestInstallCliEventReporting(unittest.TestCase):
         with patch.object(
             install_mod, "install_command", return_value=overall_success
         ), patch.object(
-            install_mod, "record_install_event"
-        ) as mock_event, patch.object(
+            install_mod, "report_install_outcome"
+        ) as mock_outcome, patch.object(
             install_mod, "flush_install_events"
         ) as mock_flush, patch.object(
             install_mod, "flush_pending_snapshot_reports"
@@ -2953,21 +3036,75 @@ class TestInstallCliEventReporting(unittest.TestCase):
                 )
             except click.exceptions.Exit:
                 pass
-        return mock_event, mock_flush
+        return mock_outcome, mock_flush
 
-    def test_successful_run_reports_succeeded_then_flushes(self):
-        mock_event, mock_flush = self._run_cli(overall_success=True)
+    def test_successful_run_closes_the_attempt_then_flushes(self):
+        mock_outcome, mock_flush = self._run_cli(overall_success=True)
 
-        mock_event.assert_called_once()
-        self.assertEqual(mock_event.call_args.args[0], "succeeded")
+        mock_outcome.assert_called_once_with(True)
         mock_flush.assert_called_once()
 
-    def test_failed_run_still_flushes_what_was_buffered(self):
-        """A failed attempt already emitted its terminal event downstream."""
-        mock_event, mock_flush = self._run_cli(overall_success=False)
+    def test_failed_run_still_closes_and_flushes(self):
+        """A failed attempt is exactly the one that needs reporting."""
+        mock_outcome, mock_flush = self._run_cli(overall_success=False)
 
-        mock_event.assert_not_called()
+        mock_outcome.assert_called_once_with(False)
         mock_flush.assert_called_once()
+
+
+class TestInstallOutcomeDecision(unittest.TestCase):
+    """`report_install_outcome` picks the single terminal event."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = g.script_directory
+        g.script_directory = self._tmp.name
+        ota._install_session_id = "session-outcome"
+        ota.clear_pending_install_failure()
+
+    def tearDown(self):
+        ota._install_session_id = None
+        ota.clear_pending_install_failure()
+        g.script_directory = self._orig
+        self._tmp.cleanup()
+
+    def _events(self):
+        return ota._read_install_event_queue()
+
+    def test_nothing_is_reported_when_ota_never_started(self):
+        self.assertIsNone(ota.report_install_outcome(True))
+        self.assertEqual(self._events(), [])
+
+    def test_clean_run_reports_succeeded(self):
+        ota.record_install_event("started")
+
+        ota.report_install_outcome(True)
+
+        self.assertEqual(
+            [e["eventType"] for e in self._events()], ["started", "succeeded"]
+        )
+
+    def test_noted_failure_outranks_an_overall_success(self):
+        """The partial-archive case: install_command returns True anyway."""
+        ota.record_install_event("started")
+        ota.note_install_failure("download", "network", "pkg3 never arrived")
+
+        ota.report_install_outcome(True)
+
+        terminal = self._events()[-1]
+        self.assertEqual(terminal["eventType"], "failed")
+        self.assertEqual(terminal["stage"], "download")
+        self.assertEqual(terminal["errorCode"], "network")
+
+    def test_failure_with_nothing_noted_still_closes_the_session(self):
+        """An open session would otherwise be read as 'stale in progress'."""
+        ota.record_install_event("started")
+
+        ota.report_install_outcome(False)
+
+        terminal = self._events()[-1]
+        self.assertEqual(terminal["eventType"], "failed")
+        self.assertEqual(terminal["errorCode"], "unknown")
 
 
 class TestInstallIntegration(unittest.TestCase):

--- a/test_ota.py
+++ b/test_ota.py
@@ -165,6 +165,7 @@ class TestConfiguration(unittest.TestCase):
                 if os.name == "posix":
                     self.assertEqual(saved_path.stat().st_mode & 0o777, 0o600)
                 self.assertEqual(ota.get_robot_api_key(), "robot-key")
+                self.assertEqual(ota._robot_api_key_cache[key_path][1], "robot-key")
 
     @unittest.skipIf(os.name != "posix", "POSIX file permission check")
     def test_insecure_robot_api_key_file_is_ignored(self):
@@ -178,6 +179,22 @@ class TestConfiguration(unittest.TestCase):
                 clear=True,
             ):
                 self.assertIsNone(ota.get_robot_api_key())
+
+    @unittest.skipIf(os.name != "posix", "POSIX file permission check")
+    def test_insecure_robot_api_key_file_warning_is_cached(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            key_path = Path(tmpdir) / "robot-api-key"
+            key_path.write_text("robot-key\n", encoding="utf-8")
+            os.chmod(key_path, 0o644)
+            with patch.dict(
+                os.environ,
+                {"RAISIN_ROBOT_API_KEY_FILE": str(key_path)},
+                clear=True,
+            ), patch("builtins.print") as mock_print:
+                self.assertIsNone(ota.get_robot_api_key())
+                self.assertIsNone(ota.get_robot_api_key())
+
+            mock_print.assert_called_once()
 
 
 # ============================================================================
@@ -663,6 +680,7 @@ class TestDownload(unittest.TestCase):
         ota._auth_failed = False
         ota._archive_cache.clear()
         ota._install_session_id = None
+        ota._robot_api_key_cache.clear()
         ota._pending_snapshot_reports.clear()
         self._orig_os_type = g.os_type
         self._orig_os_version = g.os_version

--- a/test_ota.py
+++ b/test_ota.py
@@ -1401,10 +1401,22 @@ class TestTransactionalArchiveInstall(unittest.TestCase):
         (g.script_directory, g.os_type, g.os_version, g.architecture) = self._orig
         self._tmp.cleanup()
 
+    # A real archive manifest always carries manifestHash; the snapshot
+    # contract requires it per package.
     MANIFEST = (
         [
-            {"packageName": "pkg1", "packageId": "p1", "tagName": "1.0.0"},
-            {"packageName": "pkg2", "packageId": "p2", "tagName": "1.0.0"},
+            {
+                "packageName": "pkg1",
+                "packageId": "p1",
+                "tagName": "1.0.0",
+                "manifestHash": "a" * 64,
+            },
+            {
+                "packageName": "pkg2",
+                "packageId": "p2",
+                "tagName": "1.0.0",
+                "manifestHash": "b" * 64,
+            },
         ],
         "arch-1",
         "2026.2.0",
@@ -1420,6 +1432,13 @@ class TestTransactionalArchiveInstall(unittest.TestCase):
             (install_dir / "release.yaml").write_text(
                 f"version: {version}\n", encoding="utf-8"
             )
+            # Real extraction records this; a rollback reads it back to learn
+            # which archive the restored tree belongs to.
+            metadata = kw.get("install_metadata")
+            if metadata:
+                (install_dir / "ota-install.json").write_text(
+                    json.dumps(metadata), encoding="utf-8"
+                )
             return {"version": version, "dependencies": []}
 
         return fake
@@ -1531,10 +1550,12 @@ class TestTransactionalArchiveInstall(unittest.TestCase):
             "commands.ota_client._extract_and_read_deps", side_effect=hollow
         ), patch(
             "commands.ota_client.report_software_snapshot", return_value=True
-        ):
-            return ota.download_all_from_archive(
+        ) as mock_snapshot:
+            results = ota.download_all_from_archive(
                 "release", self.live, archive_version=version
             )
+        self.last_snapshot = mock_snapshot
+        return results
 
     def test_broken_commit_rolls_back_to_the_previous_version(self):
         self._run({"pkg1", "pkg2"})
@@ -1565,6 +1586,40 @@ class TestTransactionalArchiveInstall(unittest.TestCase):
         ]
         self.assertEqual([e["eventType"] for e in terminal], ["rolled_back"])
         self.assertEqual(terminal[0]["errorCode"], "health_check_failed")
+
+    def test_rollback_reports_the_restored_archive(self):
+        """After reverting, the server still has the failed version recorded.
+
+        Nothing else corrects it: the snapshot is only sent on a successful
+        commit, so a rollback that stays silent leaves the fleet view showing
+        software the robot is no longer running.
+        """
+        self._run({"pkg1", "pkg2"})
+        ota.clear_pending_install_failure()
+        ota._install_session_id = "session-tx-snap"
+
+        self._run_with_hollow_extract("2026.3.0")
+
+        self.last_snapshot.assert_called_once()
+        reported = self.last_snapshot.call_args.kwargs
+        self.assertEqual(reported["archive_version"], "2026.2.0")
+        self.assertEqual(reported["archive_id"], "arch-1")
+        self.assertEqual(
+            sorted(p["packageName"] for p in reported["packages"]), ["pkg1", "pkg2"]
+        )
+
+    def test_a_tree_with_no_archive_metadata_is_not_reported(self):
+        """An adopted pre-versioning tree has nothing to say about an archive."""
+        legacy = self.live / "old_pkg" / "linux" / "22.04" / "x86_64" / "release"
+        legacy.mkdir(parents=True)
+        (legacy / "release.yaml").write_text("version: 0.1\n", encoding="utf-8")
+        install_tree.ensure_tree(self.release)
+        self._write_pkg_free_commit = None
+
+        with patch("builtins.print"):
+            self._run_with_hollow_extract("2026.3.0")
+
+        self.last_snapshot.assert_not_called()
 
     def test_broken_first_install_cannot_roll_back_and_says_so(self):
         """With no previous version there is nothing to restore — that is `failed`."""

--- a/test_ota.py
+++ b/test_ota.py
@@ -663,6 +663,7 @@ class TestDownload(unittest.TestCase):
         ota._auth_failed = False
         ota._archive_cache.clear()
         ota._install_session_id = None
+        ota._pending_snapshot_reports.clear()
         self._orig_os_type = g.os_type
         self._orig_os_version = g.os_version
         self._orig_architecture = g.architecture
@@ -676,6 +677,7 @@ class TestDownload(unittest.TestCase):
         ota._auth_failed = False
         ota._archive_cache.clear()
         ota._install_session_id = None
+        ota._pending_snapshot_reports.clear()
         g.os_type = self._orig_os_type
         g.os_version = self._orig_os_version
         g.architecture = self._orig_architecture
@@ -1000,6 +1002,25 @@ class TestDownload(unittest.TestCase):
             call_args.kwargs["headers"]["X-Install-Session-Id"], "session-1"
         )
 
+    @patch("commands.ota_client._get_auth_context", return_value=("tok", {}))
+    @patch("commands.ota_client.requests.get")
+    def test_stream_download_removes_partial_file_on_failure(self, mock_get, _auth):
+        def chunks():
+            yield b"partial"
+            raise ota.requests.ConnectionError("connection lost")
+
+        mock_get.return_value = _mock_response(iter_content=chunks())
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            download_path = Path(tmpdir) / "pkg.zip"
+
+            result = ota._stream_download(
+                "https://ota.example.com/pkg.zip", download_path, "mypkg"
+            )
+
+            self.assertFalse(result)
+            self.assertFalse(download_path.exists())
+
     @patch("commands.ota_client._stream_download", return_value=True)
     @patch(
         "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
@@ -1287,6 +1308,78 @@ class TestDownload(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result["version"], "1.5.0")
 
+    @patch("commands.ota_client._queue_snapshot_report")
+    @patch("commands.ota_client.get_install_session_id", return_value="session-1")
+    @patch("commands.ota_client._download_package_blob", return_value=True)
+    @patch("commands.ota_client._fetch_archive_manifest")
+    def test_download_package_defers_snapshot_report(
+        self, mock_manifest, mock_blob, _session_id, mock_queue
+    ):
+        packages = [
+            {
+                "packageName": "mypkg",
+                "tagName": "v1.2.0",
+                "packageId": "p1",
+                "manifestHash": "a" * 64,
+            }
+        ]
+        mock_manifest.return_value = (packages, "arch-1", "v2024.01")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            g.script_directory = tmpdir
+            install_base = Path(tmpdir) / "release" / "install"
+            install_base.mkdir(parents=True)
+            download_file = Path(tmpdir) / "install" / "mypkg-ota-1.2.0.zip"
+            download_file.parent.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(download_file, "w") as zf:
+                zf.writestr("release.yaml", "version: 1.2.0\n")
+
+            result = ota.download_package(
+                "mypkg", "", "release", install_base, tag=None
+            )
+
+        self.assertIsNotNone(result)
+        mock_queue.assert_called_once()
+        self.assertEqual(mock_queue.call_args.kwargs["archive_id"], "arch-1")
+        self.assertEqual(mock_queue.call_args.kwargs["install_session_id"], "session-1")
+
+    @patch("commands.ota_client._report_snapshot_from_install_metadata")
+    def test_pending_snapshot_reports_are_deduplicated_until_flush(self, mock_report):
+        install_base = Path("/tmp/install-base")
+
+        ota._queue_snapshot_report(
+            install_base_path=install_base,
+            archive_id="arch-1",
+            archive_name="dso",
+            archive_version="v1.0.3",
+            platform_str="linux-22.04-x86_64",
+            build_type="release",
+            install_session_id="session-1",
+        )
+        ota._queue_snapshot_report(
+            install_base_path=install_base,
+            archive_id="arch-1",
+            archive_name="dso",
+            archive_version="v1.0.3",
+            platform_str="linux-22.04-x86_64",
+            build_type="release",
+            install_session_id="session-1",
+        )
+
+        mock_report.assert_not_called()
+        ota.flush_pending_snapshot_reports()
+
+        mock_report.assert_called_once_with(
+            install_base_path=install_base,
+            archive_id="arch-1",
+            archive_name="dso",
+            archive_version="v1.0.3",
+            platform_str="linux-22.04-x86_64",
+            build_type="release",
+            install_session_id="session-1",
+        )
+        self.assertEqual(ota._pending_snapshot_reports, {})
+
     @patch("commands.ota_client._fetch_archive_manifest")
     def test_download_package_not_in_archive(self, mock_manifest):
         packages = [
@@ -1377,6 +1470,7 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         ota._auth_failed = False
         ota._archive_cache.clear()
         ota._install_session_id = None
+        ota._pending_snapshot_reports.clear()
         g.os_type = self._orig_os_type
         g.os_version = self._orig_os_version
         g.architecture = self._orig_architecture

--- a/test_ota.py
+++ b/test_ota.py
@@ -106,6 +106,19 @@ def _make_sshsig_pem(raw_sig=None):
 class TestConfiguration(unittest.TestCase):
     """Verify env-var-based configuration helpers."""
 
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._orig_script_directory = g.script_directory
+        g.script_directory = self._tmpdir.name
+        ota._robot_api_key_cache.clear()
+        ota._robot_auth_warning_keys.clear()
+
+    def tearDown(self):
+        ota._robot_api_key_cache.clear()
+        ota._robot_auth_warning_keys.clear()
+        g.script_directory = self._orig_script_directory
+        self._tmpdir.cleanup()
+
     def test_get_ota_endpoint_returns_default_when_unset(self):
         """Should return default endpoint when env var is not set."""
         with patch.dict(os.environ, {}, clear=True):
@@ -151,6 +164,46 @@ class TestConfiguration(unittest.TestCase):
             clear=True,
         ):
             self.assertEqual(ota.get_robot_api_key(), "robot-key")
+
+    def test_get_robot_api_key_from_config_yaml(self):
+        config_path = Path(g.script_directory) / "configuration_setting.yaml"
+        config_path.write_text(
+            "user_type: user\nrobot:\n  api_key: config-robot-key\n",
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(ota.get_robot_api_key(), "config-robot-key")
+
+    def test_get_robot_api_key_env_overrides_config_yaml(self):
+        config_path = Path(g.script_directory) / "configuration_setting.yaml"
+        config_path.write_text(
+            "user_type: user\nrobot:\n  api_key: config-robot-key\n",
+            encoding="utf-8",
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "env-robot-key",  # pragma: allowlist secret
+            },
+            clear=True,
+        ):
+            self.assertEqual(ota.get_robot_api_key(), "env-robot-key")
+
+    def test_get_robot_node_key_from_env(self):
+        with patch.dict(os.environ, {"RAISIN_ROBOT_NODE": " jetson "}, clear=True):
+            self.assertEqual(ota.get_robot_node_key(), "jetson")
+
+    def test_get_robot_node_key_from_config_yaml(self):
+        config_path = Path(g.script_directory) / "configuration_setting.yaml"
+        config_path.write_text(
+            "user_type: user\nrobot:\n  node: vision\n",
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(ota.get_robot_node_key(), "vision")
 
     def test_save_and_read_robot_api_key_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -682,13 +735,16 @@ class TestDownload(unittest.TestCase):
         ota._install_session_id = None
         ota._robot_api_key_cache.clear()
         ota._pending_snapshot_reports.clear()
+        ota._robot_auth_warning_keys.clear()
         self._orig_os_type = g.os_type
         self._orig_os_version = g.os_version
         self._orig_architecture = g.architecture
         self._orig_script_directory = g.script_directory
+        self._tmp_script_dir = tempfile.TemporaryDirectory()
         g.os_type = "linux"
         g.os_version = "22.04"
         g.architecture = "x86_64"
+        g.script_directory = self._tmp_script_dir.name
 
     def tearDown(self):
         ota._cached_token = None
@@ -696,10 +752,12 @@ class TestDownload(unittest.TestCase):
         ota._archive_cache.clear()
         ota._install_session_id = None
         ota._pending_snapshot_reports.clear()
+        ota._robot_auth_warning_keys.clear()
         g.os_type = self._orig_os_type
         g.os_version = self._orig_os_version
         g.architecture = self._orig_architecture
         g.script_directory = self._orig_script_directory
+        self._tmp_script_dir.cleanup()
 
     @patch("commands.ota_client.authenticate", return_value="tok")
     @patch(
@@ -978,6 +1036,7 @@ class TestDownload(unittest.TestCase):
                 os.environ,
                 {
                     "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                    "RAISIN_ROBOT_NODE": "jetson",
                     "RAISIN_OTA_CLIENT_VERSION": "raisin-cli-test",
                 },
                 clear=True,
@@ -1019,6 +1078,38 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(
             call_args.kwargs["headers"]["X-Install-Session-Id"], "session-1"
         )
+        self.assertEqual(call_args.kwargs["headers"]["X-Robot-Node"], "jetson")
+
+    @patch("commands.ota_client._stream_download", return_value=True)
+    @patch(
+        "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
+    )
+    def test_download_package_blob_falls_back_without_robot_node(
+        self, _ep, mock_stream
+    ):
+        with patch.dict(
+            os.environ,
+            {"RAISIN_ROBOT_API_KEY": "robot-key"},  # pragma: allowlist secret
+            clear=True,
+        ), patch("builtins.print") as mock_print:
+            result = ota._download_package_blob(
+                "arch-1",
+                "pkg-1",
+                "mypkg",
+                Path("/tmp/pkg.zip"),
+                archive_name="dso",
+                archive_version="1.0.3",
+                platform_str="ubuntu-24.04-arm64",
+                install_session_id="session-1",
+            )
+
+        self.assertTrue(result)
+        mock_stream.assert_called_once_with(
+            "https://ota.example.com/archives/arch-1/packages/pkg-1/download",
+            Path("/tmp/pkg.zip"),
+            "mypkg",
+        )
+        mock_print.assert_called_once()
 
     @patch("commands.ota_client._get_auth_context", return_value=("tok", {}))
     @patch("commands.ota_client.requests.get")
@@ -1071,12 +1162,20 @@ class TestDownload(unittest.TestCase):
     @patch("commands.ota_client.requests.post")
     def test_report_software_snapshot_posts_robot_payload(self, mock_post, _ep):
         mock_post.return_value = _mock_response()
-        packages = [{"packageId": "pkg-1", "packageName": "mypkg", "version": "1.2.0"}]
+        packages = [
+            {
+                "packageId": "00000000-0000-4000-8000-000000000201",
+                "packageName": "mypkg",
+                "version": "1.2.0",
+                "manifestHash": "a" * 64,
+            }
+        ]
 
         with patch.dict(
             os.environ,
             {
                 "RAISIN_ROBOT_API_KEY": "robot-key",  # pragma: allowlist secret
+                "RAISIN_ROBOT_NODE": "jetson",
                 "RAISIN_CLIENT_VERSION": "raisin-cli-test",
             },
             clear=True,
@@ -1102,11 +1201,13 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(
             call_args.kwargs["headers"]["X-Install-Session-Id"], "session-1"
         )
+        self.assertEqual(call_args.kwargs["headers"]["X-Robot-Node"], "jetson")
         self.assertEqual(call_args.kwargs["json"]["archiveId"], "arch-1")
         self.assertEqual(call_args.kwargs["json"]["name"], "dso")
         self.assertEqual(call_args.kwargs["json"]["version"], "1.0.3")
         self.assertEqual(call_args.kwargs["json"]["platform"], "ubuntu-24.04-arm64")
-        self.assertEqual(call_args.kwargs["json"]["packages"], packages)
+        self.assertEqual(call_args.kwargs["json"]["archivePackages"], packages)
+        self.assertNotIn("packages", call_args.kwargs["json"])
         self.assertEqual(call_args.kwargs["json"]["installSessionId"], "session-1")
         self.assertEqual(call_args.kwargs["json"]["clientVersion"], "raisin-cli-test")
 
@@ -1475,13 +1576,17 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         ota._auth_failed = False
         ota._archive_cache.clear()
         ota._install_session_id = None
+        ota._robot_api_key_cache.clear()
+        ota._robot_auth_warning_keys.clear()
         self._orig_os_type = g.os_type
         self._orig_os_version = g.os_version
         self._orig_architecture = g.architecture
         self._orig_script_directory = g.script_directory
+        self._tmp_script_dir = tempfile.TemporaryDirectory()
         g.os_type = "linux"
         g.os_version = "22.04"
         g.architecture = "x86_64"
+        g.script_directory = self._tmp_script_dir.name
 
     def tearDown(self):
         ota._cached_token = None
@@ -1489,10 +1594,13 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         ota._archive_cache.clear()
         ota._install_session_id = None
         ota._pending_snapshot_reports.clear()
+        ota._robot_api_key_cache.clear()
+        ota._robot_auth_warning_keys.clear()
         g.os_type = self._orig_os_type
         g.os_version = self._orig_os_version
         g.architecture = self._orig_architecture
         g.script_directory = self._orig_script_directory
+        self._tmp_script_dir.cleanup()
         # Clear env var if set
         if "RAISIN_ARCHIVE_NAME" in os.environ:
             del os.environ["RAISIN_ARCHIVE_NAME"]
@@ -1664,8 +1772,18 @@ class TestArchiveNameAndTimestamp(unittest.TestCase):
         self.assertCountEqual(
             report_kwargs["packages"],
             [
-                {"packageId": "p1", "packageName": "pkg1", "version": "1.0.0"},
-                {"packageId": "p2", "packageName": "pkg2", "version": "2.0.0"},
+                {
+                    "packageId": "p1",
+                    "packageName": "pkg1",
+                    "version": "1.0.0",
+                    "manifestHash": "a" * 64,
+                },
+                {
+                    "packageId": "p2",
+                    "packageName": "pkg2",
+                    "version": "2.0.0",
+                    "manifestHash": "b" * 64,
+                },
             ],
         )
 

--- a/test_ota_context.py
+++ b/test_ota_context.py
@@ -48,9 +48,10 @@ class TestOtaContext(unittest.TestCase):
         )
 
     def test_workspace_paths_come_from_the_context(self):
-        self.assertEqual(ota._install_session_path().parent, self.workspace / "install")
+        # `release/`, not `install/`: a full build deletes the latter.
+        self.assertEqual(ota._install_session_path().parent, self.workspace / "release")
         self.assertEqual(
-            ota._install_event_queue_path().parent, self.workspace / "install"
+            ota._install_event_queue_path().parent, self.workspace / "release"
         )
 
     def test_an_unconfigured_core_fails_loudly(self):
@@ -74,7 +75,7 @@ class TestOtaContext(unittest.TestCase):
         )
 
         self.assertEqual(ota._ctx().platform, "ubuntu-22.04-x86_64")
-        self.assertEqual(ota._install_session_path().parent, other / "install")
+        self.assertEqual(ota._install_session_path().parent, other / "release")
 
 
 class TestRobotIdentityIsInjected(unittest.TestCase):

--- a/test_ota_context.py
+++ b/test_ota_context.py
@@ -5,9 +5,11 @@ has no CLI, needs different values per deployment, and must not import a module
 whose contract is "the CLI filled this in". These tests pin the boundary.
 """
 
+import os
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -73,6 +75,85 @@ class TestOtaContext(unittest.TestCase):
 
         self.assertEqual(ota._ctx().platform, "ubuntu-22.04-x86_64")
         self.assertEqual(ota._install_session_path().parent, other / "install")
+
+
+class TestRobotIdentityIsInjected(unittest.TestCase):
+    """The core is told who it is; it does not go looking.
+
+    Resolving a credential means knowing about env vars, config files and a
+    developer's HOME. A robot on a service account and a developer at a shell
+    answer those differently, and the core should not have to care — nor should
+    a human running the tool on a robot be silently attributed to the robot
+    because a key file happened to be on disk.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._saved = ota._context
+
+    def tearDown(self):
+        ota._context = self._saved
+        self._tmp.cleanup()
+
+    def _configure(self, robot=None):
+        ota.configure(
+            ota.OtaContext(
+                workspace=Path(self._tmp.name),
+                os_type="ubuntu",
+                os_version="24.04",
+                architecture="arm64",
+                robot=robot,
+            )
+        )
+
+    def test_headers_come_from_the_injected_identity(self):
+        self._configure(
+            ota.RobotIdentity(
+                api_key="rk_test",  # pragma: allowlist secret
+                node_key="jetson",
+                client_version="agent/1.2",
+            )
+        )
+
+        headers = ota._robot_auth_headers("session-1")
+
+        self.assertEqual(headers["Authorization"], "Robot rk_test")
+        self.assertEqual(headers["X-Robot-Node"], "jetson")
+        self.assertEqual(headers["X-Client-Version"], "agent/1.2")
+        self.assertEqual(headers["X-Install-Session-Id"], "session-1")
+
+    def test_no_identity_means_no_robot_requests(self):
+        self._configure(robot=None)
+
+        self.assertIsNone(ota._robot_auth_headers("session-1"))
+        self.assertFalse(ota.robot_reporting_enabled())
+
+    def test_environment_alone_does_not_grant_a_robot_identity(self):
+        """The caller decides who it is — not whatever is lying on the machine."""
+        self._configure(robot=None)
+
+        with patch.dict(
+            os.environ,
+            {
+                "RAISIN_ROBOT_API_KEY": "rk_from_env",  # pragma: allowlist secret
+                "RAISIN_ROBOT_NODE": "jetson",
+            },
+            clear=True,
+        ):
+            self.assertIsNone(ota._robot_auth_headers("session-1"))
+            self.assertFalse(ota.robot_reporting_enabled())
+
+    def test_credential_resolution_is_not_the_core_s_job(self):
+        removed = [
+            "get_robot_api_key",
+            "get_robot_node_key",
+            "get_robot_api_key_path",
+            "save_robot_api_key",
+            "_load_local_config",
+        ]
+        still_here = [n for n in removed if hasattr(ota, n)]
+
+        self.assertEqual(still_here, [])
 
 
 class TestCoreDoesNotImportCliGlobals(unittest.TestCase):

--- a/test_ota_context.py
+++ b/test_ota_context.py
@@ -1,0 +1,111 @@
+"""The OTA core must be usable without the CLI's process globals.
+
+`commands.globals` is populated by `init_environment` at CLI startup. An agent
+has no CLI, needs different values per deployment, and must not import a module
+whose contract is "the CLI filled this in". These tests pin the boundary.
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import commands.ota_client as ota  # noqa: E402
+
+
+class TestOtaContext(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self._tmp.name)
+        self._saved = ota._context
+        ota.configure(
+            ota.OtaContext(
+                workspace=self.workspace,
+                os_type="ubuntu",
+                os_version="24.04",
+                architecture="arm64",
+            )
+        )
+
+    def tearDown(self):
+        ota._context = self._saved
+        self._tmp.cleanup()
+
+    def test_platform_string_is_derived_from_the_context(self):
+        self.assertEqual(ota._ctx().platform, "ubuntu-24.04-arm64")
+
+    def test_package_dir_lays_out_the_platform_segments(self):
+        base = Path("/release/install")
+
+        result = ota._ctx().package_dir(base, "raisin", "release")
+
+        self.assertEqual(
+            result, base / "raisin" / "ubuntu" / "24.04" / "arm64" / "release"
+        )
+
+    def test_workspace_paths_come_from_the_context(self):
+        self.assertEqual(ota._install_session_path().parent, self.workspace / "install")
+        self.assertEqual(
+            ota._install_event_queue_path().parent, self.workspace / "install"
+        )
+
+    def test_an_unconfigured_core_fails_loudly(self):
+        """Silently defaulting would reintroduce the coupling this removes."""
+        ota._context = None
+
+        with self.assertRaises(RuntimeError) as caught:
+            ota._ctx()
+
+        self.assertIn("configure", str(caught.exception).lower())
+
+    def test_two_contexts_do_not_bleed_into_each_other(self):
+        other = Path(self._tmp.name) / "other"
+        ota.configure(
+            ota.OtaContext(
+                workspace=other,
+                os_type="ubuntu",
+                os_version="22.04",
+                architecture="x86_64",
+            )
+        )
+
+        self.assertEqual(ota._ctx().platform, "ubuntu-22.04-x86_64")
+        self.assertEqual(ota._install_session_path().parent, other / "install")
+
+
+class TestCoreDoesNotImportCliGlobals(unittest.TestCase):
+    """The dependency that blocks extracting the core into its own package."""
+
+    CORE_MODULES = ("commands/ota_client.py", "commands/install_tree.py")
+
+    def test_core_modules_do_not_import_commands_globals(self):
+        offenders = []
+        for module in self.CORE_MODULES:
+            source = Path(module).read_text(encoding="utf-8")
+            for line_no, line in enumerate(source.splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith(("import ", "from ")) and "globals" in stripped:
+                    offenders.append(f"{module}:{line_no} {stripped}")
+
+        self.assertEqual(offenders, [])
+
+    def test_core_modules_do_not_import_commands_utils(self):
+        """`commands.utils` imports the globals module at import time."""
+        offenders = []
+        for module in self.CORE_MODULES:
+            source = Path(module).read_text(encoding="utf-8")
+            for line_no, line in enumerate(source.splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith(("import ", "from ")) and (
+                    "commands.utils" in stripped
+                    or "from commands import utils" in stripped
+                ):
+                    offenders.append(f"{module}:{line_no} {stripped}")
+
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Robot-authenticated OTA install for the client.

## What a robot can do after this

Install with its own credential alone — resolve what it should run, download, install and report, with no user credential on the machine. Verified end to end with the user credential deliberately unavailable so no fallback was possible.

## Changes

| | |
|---|---|
| **Robot authentication** | Node key sent alongside the API key; both resolved from environment, `configuration_setting.yaml`/`secrets.yaml`, or `~/.config/raisin/robot-api-key` (ignored unless `chmod 600`) |
| **Assignment-driven install** | The robot installs what it has been assigned, and stops while a halt is in effect. An explicit `--archive-name` / `--archive-version` / `--tag` still wins over the assignment |
| **Download hardening** | Digest verification; `Range`/`If-Range` resume keyed on the recorded digest; jittered exponential backoff with an attempt cap; disk-space preflight; truncation detected against the announced length; failures classified into the shared error taxonomy |
| **Install events** | On-disk JSONL queue written before any network call, so an offline machine still reports later. Event ids minted once so a replayed batch is idempotent. Exactly one `started` and one terminal event per attempt, guarded on disk so a resumed run does not double-report |
| **Transactional install** | Versioned trees with an atomic symlink switch; all-or-nothing commit; rollback on a broken switch; retention of 2 (`RAISIN_INSTALL_KEEP_VERSIONS`) |
| **Installed-software report** | Manifest hash recovered from the archive manifest for installs recorded before the field existed — installed software is reported as a whole set, so an omission reads as *uninstalled*. A rollback re-reports the restored tree, so the server is not left believing the robot runs the version that was just backed out of |
| **Injected context** | The core is handed a workspace, platform and (optionally) a robot identity rather than reading CLI process globals or hunting for credentials on disk. `cryptography` is needed only for SSH signing and is imported lazily, so a credential-only robot does not carry it |

## ⚠️ On-disk layout changes

`release/install` becomes a **symlink**:

```
release/versions/<gen>-<version>/   one complete package tree
release/install -> versions/<gen>-<version>
```

- **The path and everything under it are unchanged.** `repo_dependency_check`, `index.find_target_yamls` and `setup.deploy_install_packages` all resolve through it untouched — verified, no consumer needed a change.
- **Existing installs migrate on first run.** The current directory is *moved* (not copied — a copy needs twice the disk on the machines least likely to have it) into `versions/0001-legacy` and becomes the rollback target.
- **Manual surgery is recovered from.** Removing the link leaves the packages intact, so it is relinked. A deleted version directory leaves a dangling link, which is now treated as *nothing installed* rather than reported as a version that is not on disk.

## Behaviour to be aware of

- **Install events require a robot identity.** Without one nothing is recorded — a developer workstation has no robot to attribute events to, and buffering there grew a file that could never be flushed.
- **A partial archive install commits nothing.** Every requested package must land, or the previous version keeps running and the attempt reports why.
- **`--all` is removed.** It meant "both debug and release builds", not "all packages" — that is already the default with no package arguments. It was also the only path that committed twice per attempt.
- **An unassigned robot says so.** Previously it looked like a broken credential.
- **A halt stops the install.** It is raised, not returned as an empty result, so it cannot be read as "no archive available" and answered by installing from somewhere else.
- **A version the tree cannot name is refused,** and a commit that does not happen fails the attempt rather than printing that the switch was made.
- **`release/install` may be a symlink someone else placed.** Only relative links under `versions/` are treated as this module's own; an operator's link to another disk is left exactly as it is.
- **A `release/install` on its own filesystem is reported, not crashed on.** Neither the rename that adopts an existing tree nor the hardlink clone crosses a mount boundary; the cause is named and the install stops rather than falling back into the same location.
- **A refused request is no longer reported as a missing package.** Three `GET /packages` calls sent parameters the endpoint does not accept and were rejected outright; the rejection was caught and returned as "nothing found", so publish fell through to GitHub and a timestamp install blamed an absent package. They now query the endpoint as specified — searching and matching the name exactly, since the search is a substring match that also spans descriptions — and a rejection says so in the server's own words.

## Verification

- **238 unit tests**, written test-first.
- End to end against a running OTA server: credential-only install of a four-package archive, resume from a seeded partial, recovery from a stale partial, idempotent event replay, offline buffering, and legacy-tree migration.
- Build consumers verified against the symlinked tree.
- All test data was tagged and removed afterwards.

Run tests with `python -m unittest test_ota test_install_tree test_ota_context`.

