### PR TITLE
fix: Import fnmatch in setup command

### DIFF
--- a/commands/setup.py
+++ b/commands/setup.py
@@ -6,6 +6,7 @@ Generates message/service headers and configures CMakeLists.txt.
 
 import os
 import re
+import fnmatch
 import sys
 import glob
 import json


### PR DESCRIPTION
## 무엇

`commands/setup.py` 에 `import fnmatch` 한 줄을 추가합니다.

## 왜

`update_cmake_file()` 은 `fnmatch.fnmatch()` 를 쓰는데, 2025-11 리팩터(`48328aa`, raisin.py → commands/ 분리)에서 함수 본문만 옮겨지고 import 는 따라오지 않았습니다. `raisin.py` 9번 줄에는 아직 남아 있지만 실제로 실행되는 쪽은 `commands/setup.py` 입니다.

해당 줄은 `g.build_pattern` 이 비어있지 않을 때만 실행됩니다. 즉 대상을 지정하지 않는 전체 빌드는 이 분기를 타지 않아 영향이 없고, 대상을 지정한 빌드(README 에 문서화된 `raisin build -t release -i raibo` 등, `RAISIN_BUILD_TARGETS.yaml` 의 `raibo`/`gui`/`raidrive`)만 실패합니다.

```
File "commands/setup.py", line 921, in update_cmake_file
    if fnmatch.fnmatch(name, pattern)
NameError: name 'fnmatch' is not defined. Did you forget to import 'fnmatch'?
```

서드파티 컴파일이 다 끝난 뒤 CMakeLists 갱신 단계에서 터지므로, 체감상 빌드 후반에 죽습니다.

## 확인

- 재현: `main`(47b8c42) 을 새로 클론한 워크스페이스에서 `raisin build -t release -i raibo` → 위 NameError 로 rc=1.
- 수정 후: 같은 명령이 setup 단계를 통과해 CMake 생성·컴파일 단계로 진입(1135 타깃 빌드 진행) 확인.
- 전체 빌드 경로는 이 줄을 실행하지 않으므로 동작 변화 없음.