### PR TITLE
Upload blobs the way the endpoint accepts them

### DIFF
--- a/commands/ota_client.py
+++ b/commands/ota_client.py
@@ -1065,14 +1065,22 @@ def upload_package(
         resp.raise_for_status()
         blob_exists = _unwrap_response(resp.json()).get("exists", False)
 
-        # 3. Upload blob if needed
+        # 3. Upload blob if needed.
+        #
+        # The endpoint streams the body straight to storage and hashes it on the
+        # way through, so it takes the archive as the raw request body and reads
+        # the expected digest from `x-content-sha256`. A multipart form carrying
+        # the digest as a field is refused before anything is read, which is
+        # what publish had been sending.
         if not blob_exists:
+            blob_headers = dict(headers)
+            blob_headers["x-content-sha256"] = sha256
+            blob_headers["Content-Type"] = "application/zip"
             with open(archive_path, "rb") as f:
                 resp = requests.post(
                     f"{base}/blobs",
-                    headers=headers,
-                    files={"file": (archive_path.name, f, "application/zip")},
-                    data={"sha256": sha256},
+                    headers=blob_headers,
+                    data=f,
                     timeout=120,
                 )
                 resp.raise_for_status()

--- a/test_ota.py
+++ b/test_ota.py
@@ -713,6 +713,23 @@ class TestAuthentication(unittest.TestCase):
 class TestUpload(unittest.TestCase):
     """Verify upload_package and _compute_sha256."""
 
+    @staticmethod
+    def _package_page(name):
+        return _mock_response(
+            json_data={
+                "data": {
+                    "packages": [
+                        {"id": "other", "name": f"{name}_extra"},
+                        {"id": "pkg-1", "name": name},
+                    ],
+                    "total": 2,
+                    "page": 1,
+                    "limit": 100,
+                    "totalPages": 1,
+                }
+            }
+        )
+
     def setUp(self):
         ota._cached_token = None
         ota._auth_failed = False
@@ -789,6 +806,45 @@ class TestUpload(unittest.TestCase):
 
         self.assertTrue(result)
         self.assertEqual(mock_post.call_count, 3)
+
+    @patch("commands.ota_client.authenticate", return_value="tok")
+    @patch(
+        "commands.ota_client.get_ota_endpoint", return_value="https://ota.example.com"
+    )
+    @patch("commands.ota_client.requests.get")
+    @patch("commands.ota_client.requests.post")
+    @patch("commands.ota_client._compute_sha256", return_value="a" * 64)
+    def test_blob_upload_streams_the_body_and_names_the_hash_in_a_header(
+        self, _sha, mock_post, mock_get, _ep, _auth
+    ):
+        """`POST /blobs` takes a raw stream, not a form.
+
+        The server reads the digest from `x-content-sha256` and refuses the
+        request outright without it — a multipart body carrying `sha256` as a
+        field is a 400, so publish never uploaded anything.
+        """
+        mock_get.side_effect = [
+            _mock_response(json_data={"data": {"exists": False}}),
+            self._package_page("mypkg"),
+        ]
+        mock_post.side_effect = [
+            _mock_response(),  # blob
+            _mock_response(),  # manifest
+            _mock_response(),  # tag
+        ]
+
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp.write(b"fake-zip")
+            tmp.flush()
+            ota.upload_package(Path(tmp.name), "mypkg", "1.0.0", "release")
+        os.unlink(tmp.name)
+
+        blob_call = mock_post.call_args_list[0]
+        headers = blob_call.kwargs["headers"]
+        self.assertEqual(headers["x-content-sha256"], "a" * 64)
+        self.assertEqual(headers["Content-Type"], "application/zip")
+        self.assertNotIn("files", blob_call.kwargs)
+        self.assertIn("data", blob_call.kwargs)
 
     @patch("commands.ota_client.authenticate", return_value="tok")
     @patch(


### PR DESCRIPTION
`POST /blobs` streams the request body straight to storage and hashes it on the way through, so it takes the archive as the raw body and reads the digest it expects from `x-content-sha256`. The client was sending a multipart form with the digest as a field, which the upload interceptor refuses before reading anything:

```
400  x-content-sha256 header is required for blob upload
```

The interceptor has required that header since the blob routes were written, so no publish has ever uploaded a blob through this path. Verified against a running server: the multipart form is refused, and the same archive sent as a raw body with the header answers 201.

239 tests, written test-first — the new one asserts the request carries the digest header and no multipart body.

## Scope

Deliberately just the blob upload. Publishing fails again after this, on the manifest and tag bodies, and those are left alone: publishing is restricted to CI, and making the whole path succeed from a developer machine is not something this PR should quietly do.

Both of those were traced while testing and are recorded rather than fixed:

- The manifest body omits `sourceType`, which is required and NOT NULL, so it arrives as null and answers 500.
- The tag body describes the build (`tag`, `version`, `platform`, `buildType`) instead of referencing manifests by hash, so `CreatePackageTagUseCase` receives no hashes and throws `TypeError: hashes is not iterable`.

Neither was reported as a bad request, because both routes type their `@Body()` as `Omit<SomeDto, 'packageId'>` — a TypeScript type with no runtime existence, so validation is skipped entirely and a wrong body reaches the use case. That is `raionrobotics/raisin-package-manager#137`, and it is why these two surfaced as 500s instead of messages naming the missing fields.
