### PR TITLE
Say why a robot call came back empty, not just that it did

### DIFF
--- a/raisin_ota/client.py
+++ b/raisin_ota/client.py
@@ -1435,16 +1435,60 @@ def _robot_auth_headers(install_session_id: Optional[str] = None) -> Optional[di
     }
 
 
-def fetch_robot_desired_state() -> Optional[dict]:
+@dataclass(frozen=True)
+class RobotCallResult:
+    """What a robot-facing call produced, and why it did not.
+
+    A CLI only ever needed "did I get a document" — every failure meant "no
+    opinion, carry on". A resident agent has to act differently for each: back
+    off when throttled, stop and become visible when its credential is refused,
+    keep polling normally when the server simply has no opinion, and buffer
+    when it cannot be reached. Collapsing those into `None` makes that
+    impossible, so the reason travels with the result.
+
+    The mechanism reports; deciding what to do is the caller's.
+    """
+
+    value: Optional[dict] = None
+    status: Optional[int] = None
+    throttled: bool = False
+    retry_after: Optional[float] = None
+    unauthorized: bool = False
+    unreachable: bool = False
+    detail: Optional[str] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.value is not None
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+def _retry_after_seconds(response) -> Optional[float]:
+    """`Retry-After` as seconds, or None.
+
+    Not defaulted: how long to wait when the server does not say is a policy
+    decision, and inventing a number here would hide that it was never given.
+    """
+    raw = getattr(response, "headers", {}) or {}
+    value = raw.get("Retry-After")
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_robot_desired_state() -> RobotCallResult:
     """Ask the OTA server what this robot node is supposed to be running.
 
-    Returns the resolved desired-state document, or None when robot auth is
-    not configured or the server cannot answer. Never raises: desired state is
-    an optional refinement of the caller's own archive selection.
+    Never raises — desired state is an optional refinement of the caller's own
+    archive selection — but the reason for an empty answer is carried on the
+    result rather than discarded.
     """
     headers = _robot_auth_headers()
     if not headers:
-        return None
+        return RobotCallResult(detail="no robot credential configured")
 
     base = get_ota_endpoint().rstrip("/")
     try:
@@ -1453,14 +1497,32 @@ def fetch_robot_desired_state() -> Optional[dict]:
         )
         if resp.status_code == 404:
             # Either the node is not registered or the server predates the
-            # endpoint. Both mean "no opinion", not "install nothing".
-            return None
+            # endpoint. Both mean "no opinion", not "install nothing" — and
+            # neither is a reason to stop asking.
+            return RobotCallResult(status=404, detail="no desired state for this node")
+        if resp.status_code == 429:
+            return RobotCallResult(
+                status=429,
+                throttled=True,
+                retry_after=_retry_after_seconds(resp),
+                detail="throttled by the OTA server",
+            )
+        if resp.status_code in (401, 403):
+            return RobotCallResult(
+                status=resp.status_code,
+                unauthorized=True,
+                detail="the OTA server refused this robot credential",
+            )
         resp.raise_for_status()
         state = _unwrap_response(resp.json())
-        return state if isinstance(state, dict) else None
+        return RobotCallResult(
+            value=state if isinstance(state, dict) else None, status=resp.status_code
+        )
+    except (requests.ConnectionError, requests.Timeout) as e:
+        return RobotCallResult(unreachable=True, detail=str(e))
     except (requests.RequestException, ValueError) as e:
         print(f"⚠️ Failed to fetch OTA desired state: {e}")
-        return None
+        return RobotCallResult(detail=str(e))
 
 
 def _resolve_desired_state(platform_str: str) -> tuple:
@@ -1477,7 +1539,13 @@ def _resolve_desired_state(platform_str: str) -> tuple:
     robot credential. A server that does not send it yields None here, and the
     caller falls back to the JWT route.
     """
-    state = fetch_robot_desired_state()
+    result = fetch_robot_desired_state()
+    if result.unauthorized:
+        # Worth saying plainly: a revoked or mistyped credential otherwise
+        # reads as "the server has no opinion", and the legacy-route warnings
+        # that follow point at the wrong thing.
+        print(f"⚠️ {result.detail}.")
+    state = result.value
     if not state:
         return (False, None, None, None)
 

--- a/test_ota.py
+++ b/test_ota.py
@@ -1047,6 +1047,92 @@ class TestMalformedReleaseYaml(unittest.TestCase):
         self.assertEqual(result["dependencies"], ["depA"])
 
 
+class TestRobotCallsSayWhyTheyFailed(unittest.TestCase):
+    """An agent has to act differently for each failure; the CLI never did.
+
+    `fetch_robot_desired_state` answered `None` for a 404, a 429, a 401, a 5xx
+    and being offline alike. For a CLI that is right — all of them mean "no
+    opinion, carry on". A resident process must back off for one, stop and
+    become visible for another, and keep polling normally for a third, and it
+    cannot when they arrive as the same value.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = g.script_directory
+        g.script_directory = self._tmp.name
+        _sync_ota_context()
+        _as_robot(self)
+
+    def tearDown(self):
+        g.script_directory = self._orig
+        self._tmp.cleanup()
+
+    def _fetch(self, **kwargs):
+        with (
+            patch(
+                "raisin_ota.client.get_ota_endpoint",
+                return_value="https://ota.example.com",
+            ),
+            patch("raisin_ota.client.requests.get", **kwargs),
+        ):
+            return ota.fetch_robot_desired_state()
+
+    def test_a_document_comes_back_as_one(self):
+        result = self._fetch(
+            return_value=_mock_response(json_data={"data": {"halt": False}})
+        )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.value, {"halt": False})
+
+    def test_being_throttled_is_distinguishable(self):
+        throttled = _mock_response(status_code=429, headers={"Retry-After": "45"})
+        throttled.raise_for_status.side_effect = requests.HTTPError(response=throttled)
+
+        result = self._fetch(return_value=throttled)
+
+        self.assertFalse(result.ok)
+        self.assertTrue(result.throttled)
+        self.assertEqual(result.retry_after, 45.0)
+        self.assertFalse(result.unauthorized)
+
+    def test_a_refused_credential_is_distinguishable(self):
+        """A revoked key answers this way, and retrying it is useless and loud."""
+        refused = _mock_response(status_code=401)
+        refused.raise_for_status.side_effect = requests.HTTPError(response=refused)
+
+        result = self._fetch(return_value=refused)
+
+        self.assertTrue(result.unauthorized)
+        self.assertFalse(result.throttled)
+
+    def test_an_absent_opinion_is_not_a_failure_to_report(self):
+        """404 means the node is unknown or the server is old. Keep polling."""
+        result = self._fetch(return_value=_mock_response(status_code=404))
+
+        self.assertFalse(result.ok)
+        self.assertFalse(result.unauthorized)
+        self.assertFalse(result.throttled)
+        self.assertFalse(result.unreachable)
+
+    def test_being_offline_is_distinguishable(self):
+        result = self._fetch(side_effect=requests.ConnectionError("no route"))
+
+        self.assertTrue(result.unreachable)
+        self.assertFalse(result.unauthorized)
+
+    def test_a_missing_retry_after_is_not_invented(self):
+        """Backing off by a guessed number is the agent's decision, not this one's."""
+        throttled = _mock_response(status_code=429, headers={})
+        throttled.raise_for_status.side_effect = requests.HTTPError(response=throttled)
+
+        result = self._fetch(return_value=throttled)
+
+        self.assertTrue(result.throttled)
+        self.assertIsNone(result.retry_after)
+
+
 class TestHaltStopsTheInstall(unittest.TestCase):
     """A halt tells this node to stop. It is not "no archive available".
 


### PR DESCRIPTION
Stacked on #85 — base is `codex/extract-ota-core`, so the diff here is one commit. GitHub will retarget this to `main` when #85 merges.

## The change

`fetch_robot_desired_state()` answered `None` for a 404, a 429, a 401, a 5xx and being offline alike.

```python
# before
def fetch_robot_desired_state() -> Optional[dict]

# after
def fetch_robot_desired_state() -> RobotCallResult
    # value, status, throttled, retry_after, unauthorized, unreachable, detail
```

For the CLI that collapse was correct: every one of those means "the server has no opinion, carry on with your own selection". A resident agent cannot work that way — it has four different things to do:

| answer | what has to happen |
|---|---|
| 429 | back off, and do not retry into a limit it is already over |
| 401 / 403 | stop and become visible; retrying a revoked key is useless and loud |
| 404 | keep polling normally — the node is unknown or the server is old, neither is a reason to stop asking |
| offline | buffer and retry |

Four behaviours behind one value is not something a caller can recover from, so the reason now travels with the result. Same split the rest of the module already draws: the mechanism reports, the caller decides.

## What it deliberately does not do

`Retry-After` is read but never invented. How long to wait when the server does not say is a decision for whoever is looping, and defaulting it here would hide that it was never given — which matters, because this server currently sends a 429 **without** one. Measured, not assumed: tripping the throttle on a running instance produced `Retry-After: None`.

## One thing it fixes in the CLI

A refused credential used to read as "no opinion", so the legacy-route warnings that followed pointed at the wrong thing. It now says so.

## Verification

247 tests. Six new ones cover each outcome, and the distinctions were checked against a running server rather than only against mocks:

```
valid key      → ok,     status=200
wrong key      → unauthorized, status=401
no server      → unreachable
throttled      → 429 on the 599th request (limit 600), throttled=True
```

Throttling was verified end to end by actually tripping the limit; the unit tests cover the header parsing.

## Why it is needed now

The robot agent consumes this. Without it a poll cannot tell "slow down" from "your credential is gone" from "the server is fine and has nothing for you", and the loop treats all three the same — which it did, silently, until this landed: it fell back to its own default interval while the server had been sending one all along.
