### PR TITLE
Give every robot-facing result one vocabulary for failure

### DIFF
--- a/raisin_ota/client.py
+++ b/raisin_ota/client.py
@@ -625,35 +625,108 @@ def record_install_event(
     return event
 
 
-def flush_install_events() -> bool:
+@dataclass(frozen=True)
+class RobotCallOutcome:
+    """Why a robot-facing call did not do what was asked.
+
+    Shared because the *decisions* are shared: anything looping over these has
+    to back off when throttled, stop when its credential is refused, and
+    simply try again when it could not reach the server. Copying the six
+    fields into each result type is how two of them drift apart and a caller
+    starts handling one case on one call and not the other.
+
+    Subclasses add what the call actually produced.
+    """
+
+    status: Optional[int] = None
+    throttled: bool = False
+    retry_after: Optional[float] = None
+    unauthorized: bool = False
+    unreachable: bool = False
+    detail: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class FlushResult(RobotCallOutcome):
+    """Whether the buffered events went.
+
+    `drained` rather than `ok`: "the call succeeded" and "the queue is empty"
+    are different facts, and a server that acknowledges half a batch has
+    answered fine and left work behind.
+    """
+
+    drained: bool = False
+    remaining: int = 0
+
+
+def _retry_after_seconds(response) -> Optional[float]:
+    """`Retry-After` as seconds, or None.
+
+    Not defaulted: how long to wait when the server does not say is a policy
+    decision, and inventing a number here would hide that it was never given.
+    """
+    raw = getattr(response, "headers", {}) or {}
+    value = raw.get("Retry-After")
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def flush_install_events() -> FlushResult:
     """Send buffered install events, keeping anything the server did not ack.
 
-    Returns True only when the queue is empty afterwards, so an offline robot
-    simply tries again on the next run.
+    Never raises. `drained` is true only when the queue is empty afterwards,
+    and the reason it is not travels on the result: a caller that flushes on a
+    schedule has to know whether to back off, stop, or simply try again.
     """
     remaining = _read_install_event_queue()
     if not remaining:
-        return True
+        return FlushResult(drained=True)
 
     headers = _robot_auth_headers()
     if not headers:
-        return False
+        # A machine with no robot identity has nothing to report *as*. Not a
+        # refusal by the server, and not something to back off from.
+        return FlushResult(
+            remaining=len(remaining), detail="no robot credential configured"
+        )
 
     request_headers = dict(headers)
     request_headers["Content-Type"] = "application/json"
     base = get_ota_endpoint().rstrip("/")
     url = f"{base}/robots/me/install-events"
 
+    failure = {}
     while remaining:
         batch = remaining[:_INSTALL_EVENT_BATCH_LIMIT]
         try:
             resp = requests.post(
                 url, headers=request_headers, json={"events": batch}, timeout=15
             )
+            if resp.status_code == 429:
+                failure = {
+                    "status": 429,
+                    "throttled": True,
+                    "retry_after": _retry_after_seconds(resp),
+                    "detail": "throttled by the OTA server",
+                }
+                break
+            if resp.status_code in (401, 403):
+                failure = {
+                    "status": resp.status_code,
+                    "unauthorized": True,
+                    "detail": "the OTA server refused this robot credential",
+                }
+                break
             resp.raise_for_status()
             data = _unwrap_response(resp.json()) or {}
+        except (requests.ConnectionError, requests.Timeout) as e:
+            failure = {"unreachable": True, "detail": str(e)}
+            break
         except (requests.RequestException, ValueError) as e:
             print(f"⚠️ Failed to report OTA install events: {e}")
+            failure = {"detail": str(e)}
             break
 
         acks = data.get("acks") if isinstance(data, dict) else None
@@ -688,7 +761,7 @@ def flush_install_events() -> bool:
     _write_install_event_queue(remaining)
     if remaining:
         print(f"ℹ️  {len(remaining)} OTA install event(s) buffered for a later run.")
-    return not remaining
+    return FlushResult(drained=not remaining, remaining=len(remaining), **failure)
 
 
 def clear_install_session() -> None:
@@ -1436,26 +1509,17 @@ def _robot_auth_headers(install_session_id: Optional[str] = None) -> Optional[di
 
 
 @dataclass(frozen=True)
-class RobotCallResult:
+class RobotCallResult(RobotCallOutcome):
     """What a robot-facing call produced, and why it did not.
 
     A CLI only ever needed "did I get a document" — every failure meant "no
-    opinion, carry on". A resident agent has to act differently for each: back
-    off when throttled, stop and become visible when its credential is refused,
-    keep polling normally when the server simply has no opinion, and buffer
-    when it cannot be reached. Collapsing those into `None` makes that
-    impossible, so the reason travels with the result.
+    opinion, carry on". A resident agent has to act differently for each, so
+    the reason travels with the result.
 
     The mechanism reports; deciding what to do is the caller's.
     """
 
     value: Optional[dict] = None
-    status: Optional[int] = None
-    throttled: bool = False
-    retry_after: Optional[float] = None
-    unauthorized: bool = False
-    unreachable: bool = False
-    detail: Optional[str] = None
 
     @property
     def ok(self) -> bool:
@@ -1463,20 +1527,6 @@ class RobotCallResult:
 
     def __bool__(self) -> bool:
         return self.ok
-
-
-def _retry_after_seconds(response) -> Optional[float]:
-    """`Retry-After` as seconds, or None.
-
-    Not defaulted: how long to wait when the server does not say is a policy
-    decision, and inventing a number here would hide that it was never given.
-    """
-    raw = getattr(response, "headers", {}) or {}
-    value = raw.get("Retry-After")
-    try:
-        return float(str(value).strip())
-    except (TypeError, ValueError):
-        return None
 
 
 def fetch_robot_desired_state() -> RobotCallResult:

--- a/test_ota.py
+++ b/test_ota.py
@@ -23,6 +23,8 @@ import sys
 import tempfile
 import time
 import unittest
+from typing import Optional
+from dataclasses import dataclass
 import zipfile
 
 import requests
@@ -1133,6 +1135,143 @@ class TestRobotCallsSayWhyTheyFailed(unittest.TestCase):
         self.assertIsNone(result.retry_after)
 
 
+class TestRobotResultsSpeakOneVocabulary(unittest.TestCase):
+    """Every robot-facing result answers the same questions the same way.
+
+    A caller loops over these and decides: back off, stop, or try again. If one
+    result type spells a failure differently from another, that caller handles
+    the case on one call and silently not on the other — which is the defect
+    this whole shape exists to remove, reintroduced by copy-paste.
+    """
+
+    RESULTS = (ota.RobotCallResult, ota.FlushResult)
+    FAILURE_FIELDS = (
+        "status",
+        "throttled",
+        "retry_after",
+        "unauthorized",
+        "unreachable",
+        "detail",
+    )
+
+    def test_every_result_answers_every_failure_question(self):
+        for result_type in self.RESULTS:
+            with self.subTest(result=result_type.__name__):
+                instance = result_type()
+                for field in self.FAILURE_FIELDS:
+                    self.assertTrue(
+                        hasattr(instance, field),
+                        f"{result_type.__name__} cannot say '{field}'",
+                    )
+
+    def test_the_vocabulary_is_shared_rather_than_copied(self):
+        """Inherited, so adding a seventh question reaches every result."""
+        for result_type in self.RESULTS:
+            with self.subTest(result=result_type.__name__):
+                self.assertTrue(issubclass(result_type, ota.RobotCallOutcome))
+
+    def test_a_result_that_copied_the_fields_would_not_pass(self):
+        """A guard nothing can fail is not a guard."""
+
+        @dataclass(frozen=True)
+        class Impostor:
+            status: Optional[int] = None
+            throttled: bool = False
+            retry_after: Optional[float] = None
+            unauthorized: bool = False
+            unreachable: bool = False
+            detail: Optional[str] = None
+
+        self.assertFalse(issubclass(Impostor, ota.RobotCallOutcome))
+
+
+class TestFlushSaysWhyItDidNotDrain(unittest.TestCase):
+    """The same collapse `fetch` had, on the other robot-facing call.
+
+    It matters at exactly one moment: a site comes back from an outage and a
+    thousand robots reconnect at once, each holding a queue. Every cycle then
+    spends a poll *and* a flush, the flush is certain to fail while the fleet
+    is over its budget, and the agent cannot tell — so it spends the request
+    again next cycle. The flush doubles the load precisely when the throttle
+    is already biting.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = g.script_directory
+        g.script_directory = self._tmp.name
+        _sync_ota_context()
+        _as_robot(self)
+        ota._install_session_id = "session-flush"
+        ota.record_install_event("started", archive_name="dso")
+
+    def tearDown(self):
+        ota._install_session_id = None
+        g.script_directory = self._orig
+        self._tmp.cleanup()
+
+    def _flush(self, **kwargs):
+        with (
+            patch(
+                "raisin_ota.client.get_ota_endpoint",
+                return_value="https://ota.example.com",
+            ),
+            patch("raisin_ota.client.requests.post", **kwargs),
+        ):
+            return ota.flush_install_events()
+
+    def test_a_drained_queue_reports_as_drained(self):
+        (event,) = ota._read_install_event_queue()
+        result = self._flush(
+            return_value=_mock_response(
+                json_data={"data": {"acks": [{"eventId": event["eventId"]}]}}
+            )
+        )
+
+        self.assertTrue(result.drained)
+        self.assertEqual(result.remaining, 0)
+
+    def test_being_throttled_is_distinguishable(self):
+        throttled = _mock_response(status_code=429, headers={"Retry-After": "30"})
+        throttled.raise_for_status.side_effect = requests.HTTPError(response=throttled)
+
+        result = self._flush(return_value=throttled)
+
+        self.assertFalse(result.drained)
+        self.assertTrue(result.throttled)
+        self.assertEqual(result.retry_after, 30.0)
+
+    def test_a_refused_credential_is_distinguishable(self):
+        refused = _mock_response(status_code=401)
+        refused.raise_for_status.side_effect = requests.HTTPError(response=refused)
+
+        result = self._flush(return_value=refused)
+
+        self.assertTrue(result.unauthorized)
+        self.assertFalse(result.throttled)
+
+    def test_being_offline_is_distinguishable(self):
+        result = self._flush(side_effect=requests.ConnectionError("no route"))
+
+        self.assertTrue(result.unreachable)
+        self.assertFalse(result.drained)
+
+    def test_what_did_not_go_is_still_on_disk(self):
+        """Whatever the reason, the queue is what makes a later run useful."""
+        self._flush(side_effect=requests.ConnectionError("no route"))
+
+        self.assertEqual(len(ota._read_install_event_queue()), 1)
+
+    def test_no_credential_is_not_a_server_refusal(self):
+        """A developer machine has nothing to report as; that is not a 401."""
+        _as_robot(self, None)
+
+        result = ota.flush_install_events()
+
+        self.assertFalse(result.drained)
+        self.assertFalse(result.unauthorized)
+
+
 class TestHaltStopsTheInstall(unittest.TestCase):
     """A halt tells this node to stop. It is not "no archive available".
 
@@ -1501,7 +1640,7 @@ class TestInstallEventQueue(unittest.TestCase):
 
         result = ota.flush_install_events()
 
-        self.assertFalse(result)
+        self.assertFalse(result.drained)
         self.assertEqual(len(self._queued()), 1)
         self.assertEqual(len(posts), 1)
 
@@ -1590,9 +1729,9 @@ class TestInstallEventQueue(unittest.TestCase):
                 side_effect=requests.ConnectionError("offline"),
             ),
         ):
-            ok = ota.flush_install_events()
+            result = ota.flush_install_events()
 
-        self.assertFalse(ok)
+        self.assertFalse(result.drained)
         self.assertEqual(len(self._queued()), 1)
 
     def test_replayed_batch_keeps_the_same_event_ids(self):
@@ -1724,9 +1863,9 @@ class TestInstallEventQueue(unittest.TestCase):
         # server, which answers 401 and makes this pass for the wrong reason.
         _as_robot(self, None)
 
-        ok = ota.flush_install_events()
+        result = ota.flush_install_events()
 
-        self.assertFalse(ok)
+        self.assertFalse(result.drained)
         self.assertEqual(len(self._queued()), 1)
 
 


### PR DESCRIPTION
Stacked on #85 — base is `codex/extract-ota-core`, so this is one commit.

`flush_install_events` returned `bool`: a throttle, a refused credential, an unreachable server and a partly-acknowledged batch were all `False`. The same collapse #86 removed from `fetch_robot_desired_state`, on the other robot-facing call.

An agent flushing on a schedule has to back off for the first, stop for the second and simply try again for the third. It could not tell them apart.

## Having two of these is what showed the shape should be shared

Six of the eight fields were identical. Copying them again would have been quiet in the worst way: someone adds a seventh question to one result, and a caller starts handling that case on one call and silently not on the other — the defect this whole shape exists to remove, returning as duplication.

```
RobotCallOutcome     status, throttled, retry_after, unauthorized, unreachable, detail
  ├── RobotCallResult  + value                  what a poll came back with
  └── FlushResult      + drained, remaining     whether the queue went
```

`drained` rather than `ok`, because "the call succeeded" and "the queue is empty" are different facts. A server that acknowledges half a batch has answered fine and left work behind.

Pinned by tests rather than convention: every result must answer every failure question, and must do it by **inheriting** the vocabulary. A fourth test builds a result that copies the fields instead and confirms the check rejects it.

## Nothing is discarded on failure

Verified: an unreachable flush leaves the queue exactly as it was. The only place events are dropped is the 1000-event cap, and it says how many it dropped.

## A correction to how this was justified

It was proposed on the grounds that a flush competes with the poll for one budget, doubling the load on a fleet reconnecting after an outage. **That is wrong.** `@nestjs/throttler` keys by controller and handler as well as by IP, so each route has its own bucket — measured, with `desired-state` answering 429 while `install-events` on the same address at the same moment was unaffected.

The change stands on consistency instead: the same defect on the same kind of call, and two results that answer differently are worse than either answering badly. The places that recorded the wrong reasoning have been corrected (`raisin-package-manager#171`, the agent spec, and the fleet simulation).

## Verification

256 tests. Six cover the flush outcomes, three the shared vocabulary. The distinctions were checked against a running server, not only mocks:

```
wrong key   → unauthorized, status=401, remaining=1
no server   → unreachable,              remaining=1
throttled   → recognised as throttled rather than as a generic failure
```
