### PR TITLE
fix: build pure_cmake dependencies in a single configuration

### DIFF
--- a/commands/setup.py
+++ b/commands/setup.py
@@ -1515,7 +1515,11 @@ def build_pure_cmake_projects(
     raisin_march: Optional[str] = None,
 ):
     """
-    Build pure CMake projects in both debug and release dirs and install them to install_dir.
+    Build pure CMake projects in one configuration and install them to install_dir.
+
+    The configuration is build_type when given, otherwise RAISIN_PURE_CMAKE_TYPE,
+    otherwise release. Only one is built because install_dir is shared across
+    configurations.
 
     Uses a hash-based cache to skip rebuilding unchanged projects.
     Pass force_rebuild=True to bypass the cache and rebuild everything.
@@ -1539,11 +1543,29 @@ def build_pure_cmake_projects(
     cache = {} if force_rebuild else _load_build_cache()
     built = set()
 
-    # Determine which configurations to build
-    all_configs = [("debug", "Debug"), ("release", "Release")]
-    if build_type:
-        normalized = build_type.lower()
-        all_configs = [(t, c) for t, c in all_configs if t == normalized]
+    # Determine which configuration to build.
+    #
+    # install_prefix has no build-type component, so every configuration installs
+    # into the same directory. Building both in one run means the second one
+    # overwrites the first, and which one survives depends on install order and on
+    # the _has_project_cmake_config() cache check, which cannot tell the two apart
+    # either. Build exactly one configuration.
+    #
+    # Release is the default. Set RAISIN_PURE_CMAKE_TYPE=debug to build the pure
+    # CMake dependencies with debug info instead. Plugins built in either
+    # configuration link against whichever one is installed: the vendored projects
+    # keep build-type independent library names (e.g. GTSAM_BUILD_TYPE_POSTFIXES
+    # is forced OFF).
+    known_configs = {"debug": ("debug", "Debug"), "release": ("release", "Release")}
+    requested = (
+        build_type or os.environ.get("RAISIN_PURE_CMAKE_TYPE") or "release"
+    ).lower()
+    if requested not in known_configs:
+        raise SystemExit(
+            f"\u274c Unknown pure_cmake build type '{requested}'. "
+            "Use 'debug' or 'release'."
+        )
+    all_configs = [known_configs[requested]]
 
     print(f"🏗️  Building {len(projects)} pure CMake project(s) into: {install_prefix}")
 


### PR DESCRIPTION
## 문제

로봇 운영 워크스페이스 `install/lib/libgtsam.so.4.2.1` 이 **505 MB** 였습니다. 같은 트리의 release 산출물은 **8 MB** 입니다. 최적화 없이 빌드된 디버그 본이 설치돼 있었습니다.

## 원인

`build_pure_cmake_projects()` 의 `install_prefix` 에는 빌드타입 성분이 없습니다. 빌드 디렉토리는 `cmake-build-debug` / `cmake-build-release` 로 갈라져 있지만 설치 목적지는 한 곳입니다. 그리고 `build.py` 가 `setup()` 을 부를 때 빌드타입을 안 넘기므로 `--type release` 로 빌드해도 **디버그와 릴리스가 둘 다** 돌고, 나중 것이 앞 것을 덮습니다.

어느 쪽이 남는지는 결정적이지 않습니다.

- `setup()` 이 시작할 때 `install/` 를 비웁니다.
- 디버그 차례: `_has_project_cmake_config()` 가 아무것도 못 찾음 → 빌드·설치.
- 릴리스 차례: 방금 디버그가 설치한 `GTSAMConfig.cmake` 를 보고 `unchanged, skipping` → **설치 안 함**.

이 캐시 판정에도 빌드타입 구분이 없어서 남의 흔적을 자기 것으로 오인합니다. 결과적으로 **디버그가 최종본**으로 남습니다.

전제조건은 `4b33cf2` 의 `GTSAM_BUILD_TYPE_POSTFIXES OFF` 입니다. 이 옵션이 켜져 있으면 디버그 산출물 이름이 `libgtsamDebug.so.4` 라 애초에 덮어쓸 수 없습니다. 참고로 `depthai-core` 는 그런 장치가 아예 없어 처음부터 같은 이름이고, 지금 릴리스가 남아 있는 건 그날 설치 순서가 그랬을 뿐입니다.

## 변경

설정을 **한 벌만** 빌드합니다. 우선순위는 인자 `build_type` → 환경변수 `RAISIN_PURE_CMAKE_TYPE` → `release` 입니다.

디버그 플러그인 호환은 유지됩니다. `4b33cf2` 가 라이브러리 이름을 빌드타입과 무관하게 만든 이유가 그것이고("keeps the name build-type independent so the plugin resolves against either archive"), 릴리스 한 벌만 설치되는 쪽이 그 의도에 맞습니다. pure CMake 의존성 자체를 디버그로 파고들어야 하면 `RAISIN_PURE_CMAKE_TYPE=debug` 로 명시합니다.

부수 효과로 pure_cmake 빌드 시간이 절반이 됩니다.

## 검증

격리 워크스페이스에서 `build_pure_cmake_projects()` 를 직접 호출해 확인했습니다. 대상은 `${CMAKE_BUILD_TYPE}` 를 파일로 남기고 Config.cmake 를 설치하는 더미 프로젝트입니다.

| 조건 | 빌드된 설정 | install 최종본 |
| --- | --- | --- |
| 패치 전, 기본 | Debug, Release | **Debug** |
| 패치 후, 기본 | Release | Release |
| 패치 후, `RAISIN_PURE_CMAKE_TYPE=debug` | Debug | Debug |

## 남는 것

- 운영 트리 `install/` 복구는 이 PR 범위 밖입니다. 릴리스 산출물이 `cmake-build-release/pure_cmake/gtsam/gtsam-4.2.1/gtsam/libgtsam.so.4.2.1` 에 그대로 있어 파일 복사로 되지만, 코드가 고쳐진 뒤에 해야 다시 오염되지 않습니다. 그 워크스페이스 담당자 몫입니다.
- `install_prefix` 를 빌드타입별로 가르는 안(담당자가 언급한 "덮어쓰기를 없애는" 쪽)은 라이브러리를 찾는 소비자가 어느 경로를 볼지도 같이 정해야 해서 pure_cmake 밖으로 번집니다. 두 설정을 **동시에** 보유해야 할 필요가 확인되면 그때 별건으로 다루는 게 맞다고 봅니다.
